### PR TITLE
feat: add /init-template skill for first-time repo setup

### DIFF
--- a/.opencode/docs/quick-start.md
+++ b/.opencode/docs/quick-start.md
@@ -75,6 +75,7 @@ Ask yourself: "What department would handle this in a real studio?"
 
 | Command | What it does |
 |---------|-------------|
+| `/init-template` | First-time repo setup — customizes the cloned template with your game identity, engine, and team preferences |
 | `/start` | First-time onboarding — asks where you are, guides you to the right workflow |
 | `/help` | Context-aware "what do I do next?" — reads your current phase and artifacts |
 | `/project-stage-detect` | Analyze project state, detect stage, identify gaps |
@@ -210,7 +211,8 @@ If you already know what you need, jump directly to the relevant path:
    what excites you, what you've played, your constraints
    - Generates 3 concepts, helps you pick one, defines core loop and pillars
    - Produces a game concept document and recommends an engine
-2. **Set up the engine** — Run `/setup-engine` (uses the brainstorm recommendation)
+2. **Initialize your project** — Run `/init-template` to customize the template with your game name, engine, and clean out example files.
+3. **Set up the engine** — Run `/setup-engine` (uses the brainstorm recommendation)
    - Configures CLAUDE.md, detects knowledge gaps, populates reference docs
    - Creates `.opencode/docs/technical-preferences.md` with naming conventions,
      performance budgets, and engine-specific defaults

--- a/.opencode/docs/quick-start.md
+++ b/.opencode/docs/quick-start.md
@@ -218,21 +218,21 @@ If you already know what you need, jump directly to the relevant path:
      performance budgets, and engine-specific defaults
    - If the engine version is newer than the LLM's training data, it fetches
      current docs from the web so agents suggest correct APIs
-3. **Enhance with godot-mcp (Godot only)** — Install the optional MCP server
+4. **Enhance with godot-mcp (Godot only)** — Install the optional MCP server
    for automated editor control and smoke testing:
    ```bash
    npx @coding-solo/godot-mcp
    ```
    Once configured, run `/automated-smoke-test` to verify the project launches
    without errors.
-4. **Validate the concept** — Run `/design-review design/gdd/game-concept.md`
-5. **Decompose into systems** — Run `/map-systems` to map all systems and dependencies
-6. **Design each system** — Run `/design-system [system-name]` (or `/map-systems next`)
+5. **Validate the concept** — Run `/design-review design/gdd/game-concept.md`
+7. **Decompose into systems** — Run `/map-systems` to map all systems and dependencies
+8. **Design each system** — Run `/design-system [system-name]` (or `/map-systems next`)
    to write GDDs in dependency order
-7. **Test the core loop** — Run `/prototype [core-mechanic]`
-8. **Playtest it** — Run `/playtest-report` to validate the hypothesis
-9. **Plan the first sprint** — Run `/sprint-plan new`
-10. Start building
+9. **Test the core loop** — Run `/prototype [core-mechanic]`
+10. **Playtest it** — Run `/playtest-report` to validate the hypothesis
+11. **Plan the first sprint** — Run `/sprint-plan new`
+12. Start building
 
 ### Path B: "I know what I want to build"
 

--- a/.opencode/docs/quick-start.md
+++ b/.opencode/docs/quick-start.md
@@ -226,13 +226,13 @@ If you already know what you need, jump directly to the relevant path:
    Once configured, run `/automated-smoke-test` to verify the project launches
    without errors.
 5. **Validate the concept** — Run `/design-review design/gdd/game-concept.md`
-7. **Decompose into systems** — Run `/map-systems` to map all systems and dependencies
-8. **Design each system** — Run `/design-system [system-name]` (or `/map-systems next`)
+6. **Decompose into systems** — Run `/map-systems` to map all systems and dependencies
+7. **Design each system** — Run `/design-system [system-name]` (or `/map-systems next`)
    to write GDDs in dependency order
-9. **Test the core loop** — Run `/prototype [core-mechanic]`
-10. **Playtest it** — Run `/playtest-report` to validate the hypothesis
-11. **Plan the first sprint** — Run `/sprint-plan new`
-12. Start building
+8. **Test the core loop** — Run `/prototype [core-mechanic]`
+9. **Playtest it** — Run `/playtest-report` to validate the hypothesis
+10. **Plan the first sprint** — Run `/sprint-plan new`
+11. Start building
 
 ### Path B: "I know what I want to build"
 
@@ -292,4 +292,3 @@ AGENTS.md                          -- Master config (read this first)
     settings-local-template.md     -- Personal settings.local.json guide
     templates/                     -- 37 document templates
 ```
-

--- a/.opencode/docs/setup-requirements.md
+++ b/.opencode/docs/setup-requirements.md
@@ -4,6 +4,8 @@ This template requires a few tools to be installed for full functionality.
 All hooks fail gracefully if tools are missing — nothing will break, but
 you'll lose validation features.
 
+> **New projects:** After cloning this template, run `/init-template` before anything else. It customizes the template with your game name, engine choice, and team preferences, and cleans out example files.
+
 ## Required
 
 | Tool | Purpose | Install |

--- a/.opencode/docs/skills-reference.md
+++ b/.opencode/docs/skills-reference.md
@@ -6,6 +6,7 @@
 
 | Command | Purpose |
 |---------|---------|
+| `/init-template` | First-time repo setup. Customizes the cloned template with your game identity, engine, and team preferences. |
 | `/start` | First-time onboarding — asks where you are, then guides you to the right workflow |
 | `/help` | Context-aware "what do I do next?" — reads current stage and surfaces the required next step |
 | `/project-stage-detect` | Full project audit — detect phase, identify existence gaps, recommend next steps |

--- a/.opencode/skills/init-template/SKILL.md
+++ b/.opencode/skills/init-template/SKILL.md
@@ -8,9 +8,17 @@ allowed-tools: Read, Glob, Grep, Write, Edit, Bash, question, Task
 
 When this skill is invoked:
 
-## 1. Welcome and Prompt
+## Phase 1: Parse Arguments
 
-Welcome the user to their new project. Use `question` to gather:
+Check if CLI arguments were passed (from `argument-hint`):
+
+- `--name "My Game"` → sets game name (skips the name question below)
+- `--engine godot|unity|unreal` → sets engine (skips engine question)
+- `--reset-git` → automatically offers git reset (skips the prompt)
+
+If `--name` and `--engine` are both provided, skip the interactive prompt entirely and proceed to Phase 2 using the provided values.
+
+Otherwise, use `question` to gather missing details:
 
 ### Tab 1: Project Identity
 - **What is your game's name?** (e.g., "My Game")
@@ -24,7 +32,7 @@ Welcome the user to their new project. Use `question` to gather:
 - **Team size** (solo / small 2-5 / medium 6-15 / large 16+)
 - **Preferred model tier** (default / workhorse / lightweight) — refer to the README's Model Mapping section for options
 
-## 2. Replace README.md
+## Phase 2: Replace README.md
 
 Write a fresh README.md to the project root. Use a template structure like:
 
@@ -61,33 +69,30 @@ Type `/start` for onboarding, or browse all skills with `/`.
 
 Replace `[Game Name]`, `[One-line description]`, and `[Engine]` with the user's answers from Phase 1.
 
-## 3. Update AGENTS.md
+## Phase 3: Update AGENTS.md
 
 Read AGENTS.md and update:
 - Replace the Model Mapping section at the top with the user's engine and model preference
 - Set the engine to the user's choice
 - Remove or update any project-specific settings
 
-## 4. Update opencode.json
+## Phase 4: Update opencode.json
 
 Read opencode.json and clean it up:
 - Remove any internal-only plugin paths
 - Set project name appropriately
-- Keep the ccgs-hooks.ts plugin reference
+- Keep the ccgs-hooks.ts plugin reference only if the file actually exists: `if [ -f .opencode/plugins/ccgs-hooks.ts ]; then ...`
 
-## 5. Remove Internal Files
+## Phase 5: Remove Internal Files
 
-Delete these files/directories that are only relevant to the OCGS project itself, not to new game projects:
-- `UPGRADING.md` (user doesn't need upgrade history of the template)
-- `CONTRIBUTING.md` (project-specific contribution guide)
-- `SECURITY.md` (project-specific security policy)
-- `CODE_OF_CONDUCT.md` (replace with a reference to the GitHub default)
-- Clear `design/` directory (remove any existing GDDs, entity registries)
-- Keep `design/` directory structure but empty it
-- Clear `src/` contents (keep `.gitkeep`)
-- Clear `production/` contents (session logs, sprint plans from our dev)
+Remove these files/directories with existence guards (`rm -f` or `[ -f ] && rm`):
 
-## 6. Optional Git Reset
+- `rm -f UPGRADING.md CONTRIBUTING.md SECURITY.md CODE_OF_CONDUCT.md`
+- Clear `design/` directory contents: `rm -rf design/*` but keep the directory
+- Clear `src/` contents: `rm -rf src/*` then `touch src/.gitkeep`
+- Clear `production/` contents: `rm -rf production/*`
+
+## Phase 6: Optional Git Reset
 
 If the user selected `--reset-git` or agrees when prompted:
 - Offer to reset git history to a single commit
@@ -97,7 +102,7 @@ If the user selected `--reset-git` or agrees when prompted:
 - Delete all old tags (optional)
 - Force push if needed (warn about consequences)
 
-## 7. Summary
+## Phase 7: Summary
 
 Print a completion summary:
 

--- a/.opencode/skills/init-template/SKILL.md
+++ b/.opencode/skills/init-template/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: init-template
+description: "First-time repo setup for new projects. Transforms the cloned OCGS template into a clean, ready-to-use game project with your own identity."
+argument-hint: "[--reset-git] [--name \"My Game\"] [--engine godot|unity|unreal]"
+user-invocable: true
+allowed-tools: Read, Glob, Grep, Write, Edit, Bash, question, Task
+---
+
+When this skill is invoked:
+
+## 1. Welcome and Prompt
+
+Welcome the user to their new project. Use `question` to gather:
+
+### Tab 1: Project Identity
+- **What is your game's name?** (e.g., "My Game")
+- **What is your game's one-line description?** (e.g., "A 2D platformer about a cat in space")
+
+### Tab 2: Engine & Genre
+- **Which engine are you using?** (godot / unity / unreal)
+- **What genre best describes your game?** (e.g., platformer, RPG, puzzle, FPS, strategy)
+
+### Tab 3: Team
+- **Team size** (solo / small 2-5 / medium 6-15 / large 16+)
+- **Preferred model tier** (default / workhorse / lightweight) — refer to the README's Model Mapping section for options
+
+## 2. Replace README.md
+
+Write a fresh README.md to the project root. Use a template structure like:
+
+```markdown
+# [Game Name]
+
+> [One-line description]
+
+Built with [Engine] using [OpenCode Game Studios](https://github.com/striderZA/OpenCodeGameStudios).
+
+## Quick Start
+
+```bash
+opencode
+```
+
+Type `/start` for onboarding, or browse all skills with `/`.
+
+## Project Structure
+
+```
+/
+├── src/              # Game source code
+├── assets/           # Game assets (art, audio, vfx)
+├── design/           # Game design documents
+├── docs/             # Technical documentation
+└── production/       # Sprint plans, session logs
+```
+
+## License
+
+[Choose a license]
+```
+
+Replace `[Game Name]`, `[One-line description]`, and `[Engine]` with the user's answers from Phase 1.
+
+## 3. Update AGENTS.md
+
+Read AGENTS.md and update:
+- Replace the Model Mapping section at the top with the user's engine and model preference
+- Set the engine to the user's choice
+- Remove or update any project-specific settings
+
+## 4. Update opencode.json
+
+Read opencode.json and clean it up:
+- Remove any internal-only plugin paths
+- Set project name appropriately
+- Keep the ccgs-hooks.ts plugin reference
+
+## 5. Remove Internal Files
+
+Delete these files/directories that are only relevant to the OCGS project itself, not to new game projects:
+- `UPGRADING.md` (user doesn't need upgrade history of the template)
+- `CONTRIBUTING.md` (project-specific contribution guide)
+- `SECURITY.md` (project-specific security policy)
+- `CODE_OF_CONDUCT.md` (replace with a reference to the GitHub default)
+- Clear `design/` directory (remove any existing GDDs, entity registries)
+- Keep `design/` directory structure but empty it
+- Clear `src/` contents (keep `.gitkeep`)
+- Clear `production/` contents (session logs, sprint plans from our dev)
+
+## 6. Optional Git Reset
+
+If the user selected `--reset-git` or agrees when prompted:
+- Offer to reset git history to a single commit
+- `git checkout --orphan fresh-root`
+- `git add -A`
+- `git commit -m "Initial commit: scaffolded from OpenCode Game Studios template"`
+- Delete all old tags (optional)
+- Force push if needed (warn about consequences)
+
+## 7. Summary
+
+Print a completion summary:
+
+```
+✅ Template initialized
+
+  Project: [Game Name]
+  Engine:  [Engine]
+  Team:    [Size]
+
+  What's next:
+  - Run /setup-engine [engine] to configure your engine docs
+  - Run /brainstorm to start designing your game concept
+  - Run /start for guided onboarding
+```


### PR DESCRIPTION
## Summary

Adds `/init-template` skill for first-time repo setup, transforming the cloned OCGS template into a clean, ready-to-use game project.

### Changes
- **New `/init-template` skill**: 7-phase interactive workflow — gather project identity → replace README → update AGENTS.md → update opencode.json → remove internal files → optional git reset → completion summary
- **Updated docs**: quick-start.md (step 2), skills-reference.md (Onboarding table), setup-requirements.md (callout)

Closes #22
