### PR TITLE
feat: Workflow Selection Gate for Hybrid vs Full OCGS

### DIFF
--- a/.opencode/commands/explore.md
+++ b/.opencode/commands/explore.md
@@ -1,0 +1,8 @@
+---
+name: explore
+description: "Pre-workflow rapid prototyping for exploring multiple game ideas"
+skill: explore
+category: prototyping
+---
+
+Invokes `/explore` skill.

--- a/.opencode/skills/explore/SKILL.md
+++ b/.opencode/skills/explore/SKILL.md
@@ -1,0 +1,218 @@
+---
+name: explore
+description: "Pre-workflow rapid prototyping for exploring multiple game ideas before committing to a development workflow. Produces lightweight reports with no workflow commitment."
+argument-hint: "[concept-description]"
+user-invocable: true
+allowed-tools: Read, Glob, Grep, Write, Edit, Bash, Task
+agent: prototyper
+isolation: worktree
+---
+
+## Overview
+
+This skill is the **pre-workflow exploration lane**. Use it when you have one or more rough game ideas and want to validate them before choosing between the Hybrid workflow (lean, iterative) or the Full OCGS workflow (formal, structured).
+
+**When to use `/explore`:**
+- You have 2-4 rough ideas and want to feel them out before committing
+- You are not sure if your concept is fun, feasible, or scoped correctly
+- You want to avoid formal process overhead until you know what you're making
+
+**When NOT to use `/explore`:**
+- You already know your game and are ready to build → use `/start` directly
+- You are in the middle of production → use `/prototype` or `/hybrid-prototype`
+- You need a formal vertical slice → use `/prototype` within the full workflow
+
+**Key properties:**
+- **No workflow commitment**: Does not create `production/stage.txt`, `production/review-mode.txt`, or any production artifacts
+- **No process overhead**: No GDDs, no ADRs, no architecture, no sprint plans
+- **Time-boxed**: 1-2 days per idea maximum
+- **Isolated**: All work lives in `prototypes/explore/[idea-name]/`
+- **Composable**: Run it multiple times for multiple ideas, then compare results
+
+**Agents involved**: `prototyper` only. No director reviews, no multi-tier coordination.
+
+---
+
+## Phase 1: Define the Question (5 minutes)
+
+Read the concept description from the argument. State the **one core question** this prototype must answer. If the concept is vague, ask the user to clarify before proceeding.
+
+Examples of good questions:
+- "Does the core loop of harvesting + crafting feel satisfying for 10 minutes?"
+- "Is the combat pace too slow or too frantic with 3 enemy types?"
+- "Does the movement mechanic make exploration feel good, or tedious?"
+
+Bad question: "Is this game fun?" (Too broad. Narrow it down to one mechanic or feeling.)
+
+**Ask the user**: "The core question for this prototype is: **[question]**. Proceed?"
+
+---
+
+## Phase 2: Plan (15 minutes)
+
+Define the minimum viable prototype in 3-5 bullet points:
+
+- What is the absolute minimum code to answer the question?
+- What can be hardcoded / placeholder / skipped?
+- What is the success criteria? (e.g., "Player completes 3 crafting cycles without confusion")
+- What is the time budget? (default: 1-2 days)
+
+**Present the plan to the user and ask for confirmation.**
+
+If the user is exploring multiple ideas, remind them: "This is idea **[N]** of your exploration. Keep the scope tight so you can compare fairly."
+
+---
+
+## Phase 3: Build (1-2 days)
+
+**Ask**: "May I create the prototype directory at `prototypes/explore/[idea-name]/` and begin implementation?"
+
+If yes, create the directory. Every file must begin with:
+
+```
+// EXPLORE PROTOTYPE - NOT FOR PRODUCTION
+// Question: [Core question being tested]
+// Date: [Current date]
+// Workflow: pre-workflow exploration (no workflow committed)
+```
+
+**Rules for explore prototype code**:
+- Hardcode values freely
+- Use placeholder assets (colored squares, simple shapes, primitive meshes)
+- Skip error handling, polish, and architecture
+- Use the simplest approach that works
+- Copy code rather than importing from production
+- NEVER import from `src/` — explore prototypes are fully isolated
+- NEVER create files in `production/`, `design/`, `docs/architecture/`, or `src/`
+
+**Run the prototype** as you build. Test continuously. Fix blockers, but don't polish.
+
+If the build exceeds 2 days, **stop and report**. Exploration prototypes that drag on lose their purpose. Either reduce scope or mark as TIMEOUT.
+
+---
+
+## Phase 4: Playtest (1-2 hours)
+
+Play the prototype yourself. Then ask the user to play it. Collect observations:
+
+- What worked?
+- What felt bad?
+- Did it answer the core question?
+- Any surprising discoveries?
+- How long did it take to build?
+
+**Document findings informally** — a bulleted list is fine at this stage.
+
+---
+
+## Phase 5: Generate Report (15 minutes)
+
+Draft a lightweight report:
+
+```markdown
+# Explore Report: [Idea Name]
+
+## Question
+[The core question this prototype set out to answer]
+
+## Approach
+[What was built, time spent, shortcuts taken]
+
+## Result
+[What actually happened — specific observations]
+
+## Verdict
+[PROMISING / NEEDS_WORK / NOT_VIABLE / TIMEOUT]
+
+- **PROMISING**: The core idea works. Worth developing further.
+- **NEEDS_WORK**: The idea has potential but needs significant adjustment.
+- **NOT_VIABLE**: The idea does not work as conceived. Do not pursue.
+- **TIMEOUT**: The prototype could not be completed in the timebox. Scope was too large or the idea is too complex to explore quickly.
+
+## Reasoning
+[One paragraph explaining the verdict with evidence]
+
+## Surprises
+[Any unexpected findings that affect this or other ideas]
+
+## Estimated Production Effort
+[Rough guess: small (weeks) / medium (months) / large (6+ months)]
+```
+
+**Ask**: "May I write this report to `prototypes/explore/[idea-name]/REPORT.md`?"
+
+---
+
+## Phase 6: Next Steps
+
+After the report is written, present the user's options:
+
+**If the user has more ideas to explore:**
+> "Idea **[current idea]** is documented. You have **[N]** more ideas to explore. Ready to run `/explore [next-idea]`?"
+
+**If the user is done exploring:**
+> "Exploration complete. You have **[N]** reports in `prototypes/explore/`:
+> - `[idea-1]`: PROMISING
+> - `[idea-2]`: NOT_VIABLE
+> - `[idea-3]`: NEEDS_WORK
+>
+> **Next step**: Run `/gate-check workflow-selection` to compare your prototypes and choose between the Hybrid and Full OCGS workflows.
+>
+> Or, if you want to refine one idea first: `/explore [revised-concept]` to iterate."
+
+**Do NOT**:
+- Suggest `/design-system`, `/create-architecture`, or any production-phase skill
+- Create `production/stage.txt`
+- Set a review mode
+- Route to `/brainstorm` unless the user explicitly asks for ideation help
+
+---
+
+## Phase 7: Summary
+
+Output a summary to the user:
+- Idea name and core question
+- Verdict (PROMISING / NEEDS_WORK / NOT_VIABLE / TIMEOUT)
+- Location of the report
+- Clear next step (explore another idea, or workflow selection)
+
+Verdict: **COMPLETE** — exploration prototype finished. No workflow committed.
+
+---
+
+## Constraints
+
+- Prototype code must NEVER import from production source files
+- Production code must NEVER import from prototype directories
+- If an idea is later productionized, rewrite from scratch — do not refactor explore prototype code
+- Timebox strictly: 1-2 days per idea. If it's not testable after 2 days, verdict is TIMEOUT
+- Keep the question narrow — one prototype, one question
+- No workflow artifacts: do not touch `production/`, `design/gdd/`, `docs/architecture/`, or `src/`
+- No review mode gates, no director reviews, no multi-agent coordination
+- **Workflow isolation**: This skill explicitly bypasses `production/review-mode.txt` and `production/stage.txt`. Any existing workflow state is ignored during exploration.
+
+---
+
+## Comparison with Other Prototype Skills
+
+| Aspect | `/explore` | `/prototype` (Full OCGS) | `/hybrid-prototype` (Hybrid) |
+|--------|-----------|--------------------------|------------------------------|
+| **Workflow stage** | Pre-workflow | Phase 4 (Pre-Production) | Phase 1 (Discovery) |
+| **Workflow commitment** | None | Full OCGS | Hybrid |
+| **Creates stage.txt?** | No | Yes | Yes (hybrid stage) |
+| **Review mode gates** | None | Solo / Lean / Full | None |
+| **Report format** | Lightweight `REPORT.md` | Formal `REPORT.md` | Lightweight `DECISION.md` |
+| **Directory** | `prototypes/explore/` | `prototypes/[name]/` | `prototypes/[name]/` |
+| **Next step on success** | `/gate-check workflow-selection` | `/design-system` or `/architecture-decision` | `/design-system` or `/create-architecture` |
+| **Time budget** | 1-2 days | 1-3 days | 1-3 days |
+| **Agents involved** | `prototyper` only | All tiers | 4 core roles |
+| **Designed for** | Comparing multiple ideas | Validating a known concept | Finding the fun in one idea |
+
+---
+
+## Recommended Next Steps
+
+- **If exploring more ideas**: Run `/explore [next-concept]` for the next idea
+- **If done exploring**: Run `/gate-check workflow-selection` to choose Hybrid vs. Full OCGS
+- **If one idea needs refinement**: Run `/explore [revised-concept]` with adjusted scope
+- **If ready to commit to a workflow**: Run `/start` after workflow selection to begin formal onboarding

--- a/.opencode/skills/gate-check/SKILL.md
+++ b/.opencode/skills/gate-check/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: gate-check
 description: "Validate readiness to advance between development phases. Produces a PASS/CONCERNS/FAIL verdict with specific blockers and required artifacts. Use when user says 'are we ready to move to X', 'can we advance to production', 'check if we can start the next phase', 'pass the gate'."
-argument-hint: "[target-phase: systems-design | technical-setup | pre-production | production | polish | release] [--review full|lean|solo]"
+argument-hint: "[target-phase: workflow-selection | systems-design | technical-setup | pre-production | production | polish | release] [--review full|lean|solo]"
 user-invocable: true
 allowed-tools: Read, Glob, Grep, Bash, Write, Task, question
 model: opencode-go/kimi-k2.6
@@ -19,6 +19,7 @@ This skill is prescriptive ("are we ready to advance?" with a formal verdict).
 
 The project progresses through these stages:
 
+0. **Exploration** — Pre-workflow: rapid prototyping multiple ideas (/explore)
 1. **Concept** — Brainstorming, game concept document
 2. **Systems Design** — Mapping systems, writing GDDs
 3. **Technical Setup** — Engine config, architecture decisions
@@ -27,8 +28,9 @@ The project progresses through these stages:
 6. **Polish** — Performance, playtesting, bug fixing
 7. **Release** — Launch prep, certification
 
-**When a gate passes**, write the new stage name to `production/stage.txt`
-(single line, e.g. `Production`). This updates the status line immediately.
+**Special gate: `workflow-selection`** — Only valid from the Exploration stage.
+When it passes, it sets both `production/workflow-mode.txt` (hybrid or full) and 
+`production/stage.txt` (Concept). See the Workflow Selection gate below.
 
 ---
 
@@ -44,6 +46,7 @@ Also resolve the review mode (once, store for all gate spawns this run):
 Note: in `solo` mode, director spawns (CD-PHASE-GATE, TD-PHASE-GATE, PR-PHASE-GATE, AD-PHASE-GATE) are skipped — gate-check becomes artifact-existence checks only. In `lean` mode, all four directors still run (phase gates are the purpose of lean mode).
 
 - **With argument**: `/gate-check production` — validate readiness for that specific phase
+  `/gate-check workflow-selection` — run workflow selection (only valid from exploration stage)
 - **No argument**: Auto-detect current stage using the same heuristics as
   `/project-stage-detect`, then **confirm with the user before running**:
 
@@ -51,13 +54,137 @@ Note: in `solo` mode, director spawns (CD-PHASE-GATE, TD-PHASE-GATE, PR-PHASE-GA
   - Prompt: "Detected stage: **[current stage]**. Running gate for [Current] → [Next] transition. Is this correct?"
   - Options:
     - `[A] Yes — run this gate`
-    - `[B] No — pick a different gate` (if selected, show a second widget listing all gate options: Concept → Systems Design, Systems Design → Technical Setup, Technical Setup → Pre-Production, Pre-Production → Production, Production → Polish, Polish → Release)
-  
-  Do not skip this confirmation step when no argument is provided.
+    - `[B] No — pick a different gate` (if selected, show a second widget listing all gate options: Workflow Selection, Concept → Systems Design, Systems Design → Technical Setup, Technical Setup → Pre-Production, Pre-Production → Production, Production → Polish, Polish → Release)
+
+  **Special case — exploration stage**: If auto-detect returns `exploration`, the only valid
+  gate is `workflow-selection`. Skip the confirmation widget and proceed directly to the
+  Workflow Selection gate.
 
 ---
 
 ## 2. Phase Gate Definitions
+
+### Gate: Workflow Selection (Exploration → Hybrid or Full)
+
+This is a **pre-workflow gate**. It does not validate artifacts — it helps the user
+decide which development workflow fits their project after prototyping ideas with
+`/explore`. Unlike all other gates, this gate writes TWO files on PASS:
+`production/workflow-mode.txt` and `production/stage.txt`.
+
+**Run this when:** `production/stage.txt` reads `exploration`, or explicitly with
+`/gate-check workflow-selection`.
+
+**Required Artifacts:**
+- [ ] At least 1 prototype report in `prototypes/explore/*/REPORT.md` (or in
+      `prototypes/*/REPORT.md` from earlier prototyping)
+- [ ] Reports have a clear verdict (PROMISING / NEEDS_WORK / NOT_VIABLE / TIMEOUT)
+
+### Decision Interview
+
+Skip artifact scanning — this gate is human-driven. Use `question` to ask
+each question. Present one at a time, tally the score, then recommend. Record
+the user's answers but do not write them to a file — the output is the
+recommendation.
+
+**Question 1 — Team size:**
+- **Prompt**: "How many people are working on this project?"
+- **Options**:
+  - `Solo` — Just me (score: 0)
+  - `Small team` — 2-5 people (score: 1)
+  - `Medium team` — 6-10 people (score: 2)
+  - `Large team` — 10+ people (score: 3)
+
+**Question 2 — Timeline:**
+- **Prompt**: "What's your target timeline to a shippable game?"
+- **Options**:
+  - `Short` — Under 3 months (score: 0)
+  - `Medium` — 3-6 months (score: 1)
+  - `Long` — 6-12 months (score: 2)
+  - `Extended` — 12+ months (score: 3)
+
+**Question 3 — Design clarity:**
+- **Prompt**: "How well-defined is your game design at this point?"
+- **Options**:
+  - `Rough concept` — A theme and a mechanic, but no details (score: 0)
+  - `Some systems` — Core loop and 2-3 major systems sketched (score: 1)
+  - `Mostly designed` — Core systems, economy, and progression mapped (score: 2)
+  - `Fully documented` — Full GDDs ready to build from (score: 3)
+
+**Question 4 — External requirements:**
+- **Prompt**: "Do you have publisher, investor, or platform requirements?"
+- **Options**:
+  - `None` — Self-funded, no external obligations (score: 0)
+  - `Informal` — A publisher is interested but no contract yet (score: 1)
+  - `Contractual` — Signed deal with milestone deliverables (score: 2)
+  - `Multi-platform` — Strict cert requirements across platforms (score: 3)
+
+**Question 5 — Team experience:**
+- **Prompt**: "What's your team's experience level with shipping games?"
+- **Options**:
+  - `First game` — No shipped titles (score: 0)
+  - `Small games` — Shipped jam games or small commercial titles (score: 1)
+  - `Experienced` — Shipped 1-3 commercial titles (score: 2)
+  - `Veteran` — Shipped 3+ commercial titles (score: 3)
+
+### Scoring
+
+After all 5 questions, calculate the total score (0-15):
+
+- **Score 0-5**: Recommend **Hybrid workflow** — lightweight discovery phase,
+  then production with reduced agent roster. Best for small teams, unknown
+  designs, and short timelines.
+- **Score 6-10**: Recommend **Hybrid with upgrade path** — start with Hybrid,
+  but be ready to upgrade to Full OCGS as scope grows. Set workflow-mode to
+  `hybrid` but note the upgrade triggers.
+- **Score 11-15**: Recommend **Full OCGS workflow** — formal GDDs, ADRs,
+  full quality gates, and the complete agent roster. Best for larger teams,
+  funded projects, and long timelines.
+
+Present the recommendation:
+
+```
+## Workflow Selection Result
+
+**Score**: [N]/15
+
+**Recommended workflow**: [Hybrid / Hybrid with upgrade path / Full OCGS]
+
+**Reasoning**:
+- Team size ([answer]) → weight toward [workflow]
+- Timeline ([answer]) → weight toward [workflow]
+- Design clarity ([answer]) → weight toward [workflow]
+- External requirements ([answer]) → weight toward [workflow]
+- Team experience ([answer]) → weight toward [workflow]
+
+### Next Step
+- **If Hybrid**: Begin your concept document with `/brainstorm` or jump straight
+  into `/hybrid-prototype` with your winning idea.
+- **If Full OCGS**: Run `/brainstorm [winning-idea]` to formalize your concept,
+  then `/setup-engine` to configure the engine.
+```
+
+### User Confirmation
+
+Use `question` to confirm:
+
+- **Prompt**: "**Recommended: [Hybrid / Full OCGS]**. Does this match your intuition?"
+- **Options**:
+  - `Yes — proceed with [recommended workflow]`
+  - `No — I prefer the [other workflow] instead`
+  - `Not sure yet — I want to explore more ideas first`
+
+### Apply the Decision
+
+When the user confirms (Yes or No), write both files:
+
+1. **`production/workflow-mode.txt`** — write `hybrid` or `full` (single line)
+2. **`production/stage.txt`** — write `Concept` (single line)
+
+Always ask before writing: "May I update `production/workflow-mode.txt` to
+`[workflow]` and `production/stage.txt` to `Concept`?"
+
+If "Not sure yet", do not write anything. Advise: "Run `/explore [next-idea]`
+to prototype more ideas, then return here."
 
 ### Gate: Concept → Systems Design
 
@@ -295,7 +422,14 @@ For items that can't be automatically verified, **ask the user**:
 
 ## 4b. Director Panel Assessment
 
-Before generating the final verdict, spawn all four directors as **parallel subagents** via Task using the parallel gate protocol from `.opencode/docs/director-gates.md`. Issue all four Task calls simultaneously — do not wait for one before starting the next.
+**Skip for Workflow Selection gate**: This gate is pre-workflow — no directors
+are assigned yet. Proceed directly to the verdict output with only the artifact
+and decision interview results.
+
+**For all other gates**: Before generating the final verdict, spawn all four
+directors as **parallel subagents** via Task using the parallel gate protocol
+from `.opencode/docs/director-gates.md`. Issue all four Task calls
+simultaneously — do not wait for one before starting the next.
 
 **Spawn in parallel:**
 
@@ -368,7 +502,12 @@ Art Director:       [READY / CONCERNS / NOT READY]
 
 ## 5a. Chain-of-Verification
 
-After drafting the verdict in Phase 5, challenge it before finalising.
+**Skip for Workflow Selection gate**: The decision interview is human-driven
+and scored transparently. No artifact quality checks need verification — the
+score and recommendation are self-evident. Proceed directly to the verdict.
+
+**For all other gates**: After drafting the verdict in Phase 5, challenge it
+before finalising.
 
 **Step 1 — Generate 5 challenge questions** designed to disprove the verdict:
 
@@ -410,15 +549,20 @@ Do NOT reference the draft verdict text — re-check specific files or ask the u
 
 When the verdict is **PASS** and the user confirms they want to advance:
 
-1. Write the new stage name to `production/stage.txt` (single line, no trailing newline)
-2. This immediately updates the status line for all future sessions
+- **For Workflow Selection gate**: Write TWO files.
+  `production/workflow-mode.txt` with the selected workflow (`hybrid` or `full`),
+  and `production/stage.txt` with `Concept`.
+  ```bash
+  echo -n "[hybrid|full]" > production/workflow-mode.txt
+  echo -n "Concept" > production/stage.txt
+  ```
 
-Example: if passing the "Pre-Production → Production" gate:
-```bash
-echo -n "Production" > production/stage.txt
-```
+- **For all other gates**: Write the new stage name to `production/stage.txt`
+  (single line, no trailing newline).
 
-**Always ask before writing**: "Gate passed. May I update `production/stage.txt` to 'Production'?"
+Always ask before writing — specify both files for workflow-selection:
+- "Gate passed. May I update `production/stage.txt` to 'Production'?"
+- "Gate passed. May I set `production/workflow-mode.txt` to 'hybrid' and `production/stage.txt` to 'Concept'?"
 
 ---
 
@@ -427,6 +571,18 @@ echo -n "Production" > production/stage.txt
 After the verdict is presented and any stage.txt update is complete, close with a structured next-step prompt using `question`.
 
 **Tailor the options to the gate that just ran:**
+
+For **workflow-selection PASS**:
+```
+Gate passed. What would you like to do next?
+
+[If hybrid] [A] Run /brainstorm [winning-idea] — formalize your concept
+             [B] Run /hybrid-prototype [winning-idea] — jump straight into prototyping
+             [C] Stop here for this session
+[If full]   [A] Run /brainstorm [winning-idea] — formalize your concept
+             [B] Run /setup-engine — choose and configure your engine
+             [C] Stop here for this session
+```
 
 For **systems-design PASS**:
 ```
@@ -454,6 +610,10 @@ For all other gates, offer the two most logical next steps for that phase plus "
 
 Based on the verdict, suggest specific next steps:
 
+- **No explore prototypes yet?** → `/explore [idea-name]` to prototype ideas before workflow selection
+- **Workflow not yet selected?** → `/gate-check workflow-selection` to choose Hybrid or Full OCGS
+- **Selected Hybrid but no concept?** → `/brainstorm [winning-idea]` to formalize, then `/hybrid-prototype` to build
+- **Selected Full OCGS but no engine?** → `/setup-engine [engine-name]` to configure the engine
 - **No art bible?** → `/art-bible` to create the visual identity specification
 - **Art bible exists but no asset specs?** → `/asset-spec system:[name]` to generate per-asset visual specs and generation prompts from approved GDDs
 - **No game concept?** → `/brainstorm` to create one

--- a/.opencode/skills/help/SKILL.md
+++ b/.opencode/skills/help/SKILL.md
@@ -63,6 +63,7 @@ Check in this order:
    - "Production" → `production`
    - "Polish" → `polish`
    - "Release" → `release`
+   - "exploration" → `exploration` (pre-workflow, not in catalog)
 
 2. **If stage.txt is missing**, infer phase from artifacts (most-advanced match wins):
    - `src/` has 10+ source files → `production`
@@ -70,7 +71,35 @@ Check in this order:
    - `docs/architecture/adr-*.md` exists → `technical-setup`
    - `design/gdd/systems-index.md` exists → `systems-design`
    - `design/gdd/game-concept.md` exists → `concept`
+   - `prototypes/explore/*/REPORT.md` exists → `exploration` (pre-workflow, no concept yet)
+   - `prototypes/explore/` directory exists (any files) → `exploration`
    - Nothing → `concept` (fresh project)
+
+3. **If phase is `exploration`**: Return early with exploration-specific guidance.
+   This phase is not in the catalog — skip Steps 4-8 and go directly to reporting.
+
+   Read `prototypes/explore/` to find existing reports. Count how many ideas
+   have been prototyped and list their verdicts.
+
+   ```
+   ## Where You Are: Pre-Workflow Exploration
+
+   You are prototyping game ideas before committing to a development workflow.
+   No workflow is selected yet — no GDDs, no architecture, no sprint plans.
+
+   **Exploration prototypes found: [N]**
+   [List each with verdict from REPORT.md]
+
+   ### → Next up
+   **[Explore another idea]** — Run `/explore [description]` to prototype a new idea.
+   **[Or: Select a workflow]** — When you're done exploring, run
+   `/gate-check workflow-selection` to compare your prototypes and choose
+   between Hybrid (lean, iterative) and Full OCGS (formal, structured).
+
+   ### ~ Also available
+   - `/gate-check workflow-selection` — compare prototypes and choose workflow
+   - `/explore [idea]` — prototype another idea
+   ```
 
 ---
 

--- a/.opencode/skills/start/SKILL.md
+++ b/.opencode/skills/start/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: start
-description: "First-time onboarding — asks where you are, then guides you to the right workflow. No assumptions."
+description: "First-time onboarding — asks where you are, then guides you to the right workflow or to pre-workflow exploration. No assumptions."
 argument-hint: "[no arguments]"
 user-invocable: true
 allowed-tools: Read, Glob, Grep, Write, question
@@ -8,7 +8,9 @@ allowed-tools: Read, Glob, Grep, Write, question
 
 # Guided Onboarding
 
-This skill writes one file: `production/review-mode.txt` (review mode config set in Phase 3b).
+This skill writes up to two files:
+- `production/stage.txt` — set to `exploration` when user picks Path E (pre-workflow exploration).
+- `production/review-mode.txt` — review mode config (set in Phase 3b, skipped for Path E).
 
 This skill is the entry point for new users. It does NOT assume you have a game idea, an engine preference, or any prior experience. It asks first, then routes you to the right workflow.
 
@@ -40,6 +42,7 @@ This is the first thing the user sees. Use `question` with these exact options s
   - `B) Vague idea` — I have a rough theme, feeling, or genre in mind (e.g., "something with space" or "a cozy farming game") but nothing concrete.
   - `C) Clear concept` — I know the core idea — genre, basic mechanics, maybe a pitch sentence — but haven't formalized it into documents yet.
   - `D) Existing work` — I already have design docs, prototypes, code, or significant planning done. I want to organize or continue the work.
+  - `E) Multiple ideas` — I have 2-4 rough game ideas and want to prototype them quickly before committing to a specific workflow.
 
 Wait for the user's selection. Do not proceed until they respond.
 
@@ -161,11 +164,35 @@ The user needs creative exploration before anything else.
    - `/architecture-review` — bootstrap the TR requirement registry
    - `/gate-check` — validate readiness for next phase
 
+#### If E: Multiple ideas to explore
+
+The user wants to explore several rough ideas before committing to a workflow.
+
+1. Acknowledge that prototyping before committing is a good approach
+2. Briefly explain what `/explore` does (pre-workflow rapid prototyping — build throwaway prototypes in `prototypes/explore/`, produces lightweight `REPORT.md` per idea, no workflow commitment, 1-2 days per idea)
+3. Recommend running `/explore [idea-name]` for their first idea, then more for subsequent ideas
+4. Show the recommended path:
+
+   **Pre-workflow exploration:**
+   - `/explore idea-a` — build a prototype for the first idea (1-2 days)
+   - `/explore idea-b` — build a prototype for the second idea (1-2 days)
+   - `/explore idea-c` — (optional) build a prototype for the third idea
+   - Review reports in `prototypes/explore/*/REPORT.md`
+   - `/gate-check workflow-selection` — compare results and choose Hybrid or Full OCGS
+
+5. **Do NOT** ask about engine preferences, review modes, or any workflow-specific setup. The user is in pre-workflow exploration.
+
+6. Write `production/stage.txt` with value `exploration` so that `/help` and other skills know the project is in the exploration phase. Create the `production/` directory if it does not exist.
+
+   This is the only file Path E writes. No `production/review-mode.txt` is created.
+
 ---
 
 ## Phase 3b: Set Review Mode
 
-Check if `production/review-mode.txt` already exists.
+**If the user chose Path E (exploration)**: Skip this phase entirely. No review mode is needed for pre-workflow exploration. Proceed directly to Phase 4.
+
+**For all other paths**: Check if `production/review-mode.txt` already exists.
 
 **If it exists**: Read it and show the current mode — "Review mode is set to `[current]`." — then proceed to Phase 4. Do not ask again.
 
@@ -212,6 +239,8 @@ Verdict: **COMPLETE** — user oriented and handed off to next step.
 - **User picks D but project is empty**: Gently redirect — "It looks like the project is a fresh template with no artifacts yet. Would Path A or B be a better fit?"
 - **User picks A but project has code**: Mention what you found — "I noticed there's already code in `src/`. Did you mean to pick D (existing work)?"
 - **User is returning (engine configured, concept exists)**: Skip onboarding entirely — "It looks like you're already set up! Your engine is [X] and you have a game concept at `design/gdd/game-concept.md`. Review mode: `[read from production/review-mode.txt, or 'lean (default)' if missing]`. Want to pick up where you left off? Try `/sprint-plan` or just tell me what you'd like to work on."
+- **User is returning with exploration stage** (`production/stage.txt` reads `exploration`): Skip full onboarding — "It looks like you're exploring game ideas! You have [N] explore prototypes in `prototypes/explore/`. Want to run `/explore [another-idea]`, or are you ready to run `/gate-check workflow-selection` to choose a workflow?"
+- **User picks E but has existing project artifacts**: Detect if `production/stage.txt` already has a non-exploration value. If so, warn: "It looks like you already have a project in the [phase] phase. Did you mean to continue that work (Path D) instead?"
 - **User doesn't fit any option**: Let them describe their situation in their own words and adapt.
 
 ---

--- a/docs/WORKFLOW-GUIDE.md
+++ b/docs/WORKFLOW-GUIDE.md
@@ -63,6 +63,9 @@ This guided onboarding asks where you are and routes you to the right phase:
 - **Path D1** -- Existing project, few artifacts: normal flow
 - **Path D2** -- Existing project, GDDs/ADRs exist: runs `/project-stage-detect`
   then `/adopt` for brownfield migration
+- **Path E** -- Multiple ideas to explore: routes to `/explore` for rapid
+  pre-workflow prototyping, then `/gate-check workflow-selection` to choose
+  Hybrid vs. Full OCGS based on results
 
 ### Step 3: Verify Hooks Are Working
 
@@ -122,6 +125,8 @@ docs/                 # Technical documentation
   postmortems/        # Post-mortems
 tests/                # Test suites
 prototypes/           # Throwaway prototypes
+  explore/            # Pre-workflow exploration prototypes (/explore)
+  archive/            # Archived prototypes after workflow selection
 production/           # Sprint plans, milestones, releases
   sprints/
   milestones/
@@ -1462,7 +1467,7 @@ conflicts go to `producer`.
 | `/story-done` | 8-phase story completion review | 5 |
 | `/estimate` | Effort estimation with risk assessment | 4-5 |
 
-#### Reviews and Analysis (10)
+#### Reviews and Analysis (11)
 
 | Command | Purpose | Phase |
 |---------|---------|-------|
@@ -1475,6 +1480,7 @@ conflicts go to `producer`.
 | `/perf-profile` | Performance profiling workflow | 6 |
 | `/tech-debt` | Tech debt scanning and prioritization | 6 |
 | `/gate-check` | Formal phase gate with PASS/CONCERNS/FAIL | All transitions |
+| `/gate-check workflow-selection` | Choose Hybrid vs. Full after exploration | Pre-workflow |
 | `/reverse-document` | Generate design docs from existing code | Any |
 
 #### QA and Testing (9)
@@ -1512,11 +1518,13 @@ conflicts go to `producer`.
 | `/patch-notes` | Player-facing patch notes | 7 |
 | `/hotfix` | Emergency fix workflow | 7+ |
 
-#### Creative (2)
+#### Creative (4)
 
 | Command | Purpose | Phase |
 |---------|---------|-------|
+| `/explore` | Pre-workflow rapid prototyping — no workflow commitment | Pre-workflow |
 | `/prototype` | Throwaway prototype in isolated worktree | 4 |
+| `/hybrid-prototype` | Fast-lane prototype for hybrid discovery phase | Discovery |
 | `/localize` | String extraction and validation | 6-7 |
 
 #### Team Orchestration (9)
@@ -1549,7 +1557,20 @@ conflicts go to `producer`.
 7. /design-system per system (guided GDD authoring)
 ```
 
-### Workflow 2: "I have designs and want to start coding"
+### Workflow 2: "I have multiple ideas and want to explore before committing"
+
+```
+1. /start (pick Path E — multiple ideas to explore)
+2. /explore idea-a (rapid prototype, 1-2 days)
+3. /explore idea-b (rapid prototype, 1-2 days)
+4. /explore idea-c (optional, 1-2 days)
+5. Review reports in prototypes/explore/*/REPORT.md
+6. /gate-check workflow-selection (choose Hybrid vs. Full OCGS)
+7. If Hybrid: run /hybrid-prototype on the winning idea
+8. If Full: run /brainstorm [winning idea] to formalize, then /setup-engine
+```
+
+### Workflow 3: "I have designs and want to start coding"
 
 ```
 1. /design-review on each GDD (make sure they're solid)
@@ -1564,7 +1585,7 @@ conflicts go to `producer`.
 10. /story-readiness -> implement -> /story-done (story lifecycle)
 ```
 
-### Workflow 3: "I need to add a complex feature mid-production"
+### Workflow 4: "I need to add a complex feature mid-production"
 
 ```
 1. /design-system or /quick-design (depending on scope)
@@ -1576,7 +1597,7 @@ conflicts go to `producer`.
 7. /balance-check if it affects game balance
 ```
 
-### Workflow 4: "Something broke in production"
+### Workflow 5: "Something broke in production"
 
 ```
 1. /hotfix "description of the issue"
@@ -1587,7 +1608,7 @@ conflicts go to `producer`.
 6. Deploy and backport
 ```
 
-### Workflow 5: "I have an existing project and want to use this system"
+### Workflow 6: "I have an existing project and want to use this system"
 
 ```
 1. /start (choose Path D -- existing work)
@@ -1598,7 +1619,7 @@ conflicts go to `producer`.
 6. /gate-check at appropriate transition
 ```
 
-### Workflow 6: "Starting a new sprint"
+### Workflow 7: "Starting a new sprint"
 
 ```
 1. /retrospective (review last sprint)
@@ -1610,7 +1631,7 @@ conflicts go to `producer`.
 7. /sprint-status for quick progress checks
 ```
 
-### Workflow 7: "Shipping the game"
+### Workflow 8: "Shipping the game"
 
 ```
 1. /gate-check polish (verify Polish phase is complete)

--- a/docs/hybrid-workflow.md
+++ b/docs/hybrid-workflow.md
@@ -6,7 +6,9 @@ This document defines a pragmatic hybrid workflow that balances **creative agili
 
 **When to use this workflow**: Small teams, unknown designs, short timelines (weeks to a few months), prototypes that may be pivoted or killed.
 
-**When to use the full OCGS workflow**: Large teams (5–15+), known designs, long timelines (6+ months), funded projects with publisher requirements.
+**When to use the full OCGS workflow**: Large teams (5-15+), known designs, long timelines (6+ months), funded projects with publisher requirements.
+
+**Not sure which workflow to use?** Run `/explore` to rapidly prototype 2-4 ideas with zero workflow commitment, then use `/gate-check workflow-selection` to choose the right workflow based on your results. See [Pre-Workflow Exploration](#pre-workflow-exploration) below.
 
 ---
 
@@ -158,6 +160,57 @@ Switch back to the **full 49-agent framework** if any of these become true:
 | Coordination (late) | Excellent | Good |
 | Team size | 5–15 | 1–5 |
 | Best for | Known game, funded, long timeline | Unknown game, indie, iterating |
+
+---
+
+## Pre-Workflow Exploration
+
+Before committing to Hybrid or Full OCGS, you can explore multiple ideas rapidly with **zero workflow commitment**.
+
+### The `/explore` Skill
+
+```
+/explore "a farming sim where crops grow in real time"
+/explore "a roguelike where weapons break permanently"
+/explore "a narrative puzzle game with time loops"
+```
+
+**What `/explore` does:**
+- Builds a throwaway prototype in `prototypes/explore/[idea-name]/`
+- Time-boxed to 1-2 days per idea
+- Produces a lightweight `REPORT.md` with a verdict: **PROMISING / NEEDS_WORK / NOT_VIABLE / TIMEOUT**
+- Does NOT create `production/stage.txt`, `production/review-mode.txt`, or any workflow artifacts
+- Does NOT require choosing Hybrid vs. Full upfront
+
+**When to use it:**
+- You have 2-4 rough ideas and want to compare them before committing
+- You are not sure if your concept is fun, feasible, or correctly scoped
+- You want to avoid formal process overhead until you know what you're making
+
+**Exploration workflow:**
+
+```
+/explore idea-a          → prototypes/explore/idea-a/REPORT.md
+/explore idea-b          → prototypes/explore/idea-b/REPORT.md
+/explore idea-c          → prototypes/explore/idea-c/REPORT.md
+
+/gate-check workflow-selection
+    → Compare prototypes
+    → Choose Hybrid or Full
+    → Set workflow mode and stage
+```
+
+### How `/explore` Differs from Other Prototype Skills
+
+| Aspect | `/explore` | `/hybrid-prototype` | `/prototype` (Full OCGS) |
+|--------|-----------|---------------------|--------------------------|
+| **Workflow stage** | Pre-workflow | Hybrid Discovery | Full OCGS Pre-Production |
+| **Workflow commitment** | None | Hybrid | Full OCGS |
+| **Creates stage.txt?** | No | Yes | Yes |
+| **Time budget** | 1-2 days | 1-3 days | 1-3 days |
+| **Report** | Lightweight REPORT.md | DECISION.md | Formal REPORT.md |
+| **Next step** | Workflow selection | Begin GDD/architecture | Begin GDD/architecture |
+| **Agents** | `prototyper` only | 4 core roles | All tiers |
 
 ---
 


### PR DESCRIPTION
## Summary
Adds \/gate-check workflow-selection\ as a pre-workflow gate that helps developers choose between Hybrid and Full OCGS workflows after exploring multiple game ideas.

## Changes
- New Workflow Selection gate definition with 5-question decision interview
- Scoring logic (0-15) maps to hybrid / hybrid-with-upgrade / full
- Dual-file write: \production/workflow-mode.txt\ + \production/stage.txt\
- Skips director panel and chain-of-verification (pre-workflow, human-driven)
- Exploration stage added to production stages (stage 0)
- Auto-detect exploration maps to workflow-selection gate
- Closing widget with workflow-specific next steps

Closes #43