### PR TITLE
docs: Decision criteria and case studies for Hybrid vs Full OCGS

### DIFF
--- a/.opencode/commands/explore.md
+++ b/.opencode/commands/explore.md
@@ -1,0 +1,8 @@
+---
+name: explore
+description: "Pre-workflow rapid prototyping for exploring multiple game ideas"
+skill: explore
+category: prototyping
+---
+
+Invokes `/explore` skill.

--- a/.opencode/skills/explore/SKILL.md
+++ b/.opencode/skills/explore/SKILL.md
@@ -1,0 +1,218 @@
+---
+name: explore
+description: "Pre-workflow rapid prototyping for exploring multiple game ideas before committing to a development workflow. Produces lightweight reports with no workflow commitment."
+argument-hint: "[concept-description]"
+user-invocable: true
+allowed-tools: Read, Glob, Grep, Write, Edit, Bash, Task
+agent: prototyper
+isolation: worktree
+---
+
+## Overview
+
+This skill is the **pre-workflow exploration lane**. Use it when you have one or more rough game ideas and want to validate them before choosing between the Hybrid workflow (lean, iterative) or the Full OCGS workflow (formal, structured).
+
+**When to use `/explore`:**
+- You have 2-4 rough ideas and want to feel them out before committing
+- You are not sure if your concept is fun, feasible, or scoped correctly
+- You want to avoid formal process overhead until you know what you're making
+
+**When NOT to use `/explore`:**
+- You already know your game and are ready to build → use `/start` directly
+- You are in the middle of production → use `/prototype` or `/hybrid-prototype`
+- You need a formal vertical slice → use `/prototype` within the full workflow
+
+**Key properties:**
+- **No workflow commitment**: Does not create `production/stage.txt`, `production/review-mode.txt`, or any production artifacts
+- **No process overhead**: No GDDs, no ADRs, no architecture, no sprint plans
+- **Time-boxed**: 1-2 days per idea maximum
+- **Isolated**: All work lives in `prototypes/explore/[idea-name]/`
+- **Composable**: Run it multiple times for multiple ideas, then compare results
+
+**Agents involved**: `prototyper` only. No director reviews, no multi-tier coordination.
+
+---
+
+## Phase 1: Define the Question (5 minutes)
+
+Read the concept description from the argument. State the **one core question** this prototype must answer. If the concept is vague, ask the user to clarify before proceeding.
+
+Examples of good questions:
+- "Does the core loop of harvesting + crafting feel satisfying for 10 minutes?"
+- "Is the combat pace too slow or too frantic with 3 enemy types?"
+- "Does the movement mechanic make exploration feel good, or tedious?"
+
+Bad question: "Is this game fun?" (Too broad. Narrow it down to one mechanic or feeling.)
+
+**Ask the user**: "The core question for this prototype is: **[question]**. Proceed?"
+
+---
+
+## Phase 2: Plan (15 minutes)
+
+Define the minimum viable prototype in 3-5 bullet points:
+
+- What is the absolute minimum code to answer the question?
+- What can be hardcoded / placeholder / skipped?
+- What is the success criteria? (e.g., "Player completes 3 crafting cycles without confusion")
+- What is the time budget? (default: 1-2 days)
+
+**Present the plan to the user and ask for confirmation.**
+
+If the user is exploring multiple ideas, remind them: "This is idea **[N]** of your exploration. Keep the scope tight so you can compare fairly."
+
+---
+
+## Phase 3: Build (1-2 days)
+
+**Ask**: "May I create the prototype directory at `prototypes/explore/[idea-name]/` and begin implementation?"
+
+If yes, create the directory. Every file must begin with:
+
+```
+// EXPLORE PROTOTYPE - NOT FOR PRODUCTION
+// Question: [Core question being tested]
+// Date: [Current date]
+// Workflow: pre-workflow exploration (no workflow committed)
+```
+
+**Rules for explore prototype code**:
+- Hardcode values freely
+- Use placeholder assets (colored squares, simple shapes, primitive meshes)
+- Skip error handling, polish, and architecture
+- Use the simplest approach that works
+- Copy code rather than importing from production
+- NEVER import from `src/` — explore prototypes are fully isolated
+- NEVER create files in `production/`, `design/`, `docs/architecture/`, or `src/`
+
+**Run the prototype** as you build. Test continuously. Fix blockers, but don't polish.
+
+If the build exceeds 2 days, **stop and report**. Exploration prototypes that drag on lose their purpose. Either reduce scope or mark as TIMEOUT.
+
+---
+
+## Phase 4: Playtest (1-2 hours)
+
+Play the prototype yourself. Then ask the user to play it. Collect observations:
+
+- What worked?
+- What felt bad?
+- Did it answer the core question?
+- Any surprising discoveries?
+- How long did it take to build?
+
+**Document findings informally** — a bulleted list is fine at this stage.
+
+---
+
+## Phase 5: Generate Report (15 minutes)
+
+Draft a lightweight report:
+
+```markdown
+# Explore Report: [Idea Name]
+
+## Question
+[The core question this prototype set out to answer]
+
+## Approach
+[What was built, time spent, shortcuts taken]
+
+## Result
+[What actually happened — specific observations]
+
+## Verdict
+[PROMISING / NEEDS_WORK / NOT_VIABLE / TIMEOUT]
+
+- **PROMISING**: The core idea works. Worth developing further.
+- **NEEDS_WORK**: The idea has potential but needs significant adjustment.
+- **NOT_VIABLE**: The idea does not work as conceived. Do not pursue.
+- **TIMEOUT**: The prototype could not be completed in the timebox. Scope was too large or the idea is too complex to explore quickly.
+
+## Reasoning
+[One paragraph explaining the verdict with evidence]
+
+## Surprises
+[Any unexpected findings that affect this or other ideas]
+
+## Estimated Production Effort
+[Rough guess: small (weeks) / medium (months) / large (6+ months)]
+```
+
+**Ask**: "May I write this report to `prototypes/explore/[idea-name]/REPORT.md`?"
+
+---
+
+## Phase 6: Next Steps
+
+After the report is written, present the user's options:
+
+**If the user has more ideas to explore:**
+> "Idea **[current idea]** is documented. You have **[N]** more ideas to explore. Ready to run `/explore [next-idea]`?"
+
+**If the user is done exploring:**
+> "Exploration complete. You have **[N]** reports in `prototypes/explore/`:
+> - `[idea-1]`: PROMISING
+> - `[idea-2]`: NOT_VIABLE
+> - `[idea-3]`: NEEDS_WORK
+>
+> **Next step**: Run `/gate-check workflow-selection` to compare your prototypes and choose between the Hybrid and Full OCGS workflows.
+>
+> Or, if you want to refine one idea first: `/explore [revised-concept]` to iterate."
+
+**Do NOT**:
+- Suggest `/design-system`, `/create-architecture`, or any production-phase skill
+- Create `production/stage.txt`
+- Set a review mode
+- Route to `/brainstorm` unless the user explicitly asks for ideation help
+
+---
+
+## Phase 7: Summary
+
+Output a summary to the user:
+- Idea name and core question
+- Verdict (PROMISING / NEEDS_WORK / NOT_VIABLE / TIMEOUT)
+- Location of the report
+- Clear next step (explore another idea, or workflow selection)
+
+Verdict: **COMPLETE** — exploration prototype finished. No workflow committed.
+
+---
+
+## Constraints
+
+- Prototype code must NEVER import from production source files
+- Production code must NEVER import from prototype directories
+- If an idea is later productionized, rewrite from scratch — do not refactor explore prototype code
+- Timebox strictly: 1-2 days per idea. If it's not testable after 2 days, verdict is TIMEOUT
+- Keep the question narrow — one prototype, one question
+- No workflow artifacts: do not touch `production/`, `design/gdd/`, `docs/architecture/`, or `src/`
+- No review mode gates, no director reviews, no multi-agent coordination
+- **Workflow isolation**: This skill explicitly bypasses `production/review-mode.txt` and `production/stage.txt`. Any existing workflow state is ignored during exploration.
+
+---
+
+## Comparison with Other Prototype Skills
+
+| Aspect | `/explore` | `/prototype` (Full OCGS) | `/hybrid-prototype` (Hybrid) |
+|--------|-----------|--------------------------|------------------------------|
+| **Workflow stage** | Pre-workflow | Phase 4 (Pre-Production) | Phase 1 (Discovery) |
+| **Workflow commitment** | None | Full OCGS | Hybrid |
+| **Creates stage.txt?** | No | Yes | Yes (hybrid stage) |
+| **Review mode gates** | None | Solo / Lean / Full | None |
+| **Report format** | Lightweight `REPORT.md` | Formal `REPORT.md` | Lightweight `DECISION.md` |
+| **Directory** | `prototypes/explore/` | `prototypes/[name]/` | `prototypes/[name]/` |
+| **Next step on success** | `/gate-check workflow-selection` | `/design-system` or `/architecture-decision` | `/design-system` or `/create-architecture` |
+| **Time budget** | 1-2 days | 1-3 days | 1-3 days |
+| **Agents involved** | `prototyper` only | All tiers | 4 core roles |
+| **Designed for** | Comparing multiple ideas | Validating a known concept | Finding the fun in one idea |
+
+---
+
+## Recommended Next Steps
+
+- **If exploring more ideas**: Run `/explore [next-concept]` for the next idea
+- **If done exploring**: Run `/gate-check workflow-selection` to choose Hybrid vs. Full OCGS
+- **If one idea needs refinement**: Run `/explore [revised-concept]` with adjusted scope
+- **If ready to commit to a workflow**: Run `/start` after workflow selection to begin formal onboarding

--- a/.opencode/skills/help/SKILL.md
+++ b/.opencode/skills/help/SKILL.md
@@ -63,6 +63,7 @@ Check in this order:
    - "Production" → `production`
    - "Polish" → `polish`
    - "Release" → `release`
+   - "exploration" → `exploration` (pre-workflow, not in catalog)
 
 2. **If stage.txt is missing**, infer phase from artifacts (most-advanced match wins):
    - `src/` has 10+ source files → `production`
@@ -70,7 +71,35 @@ Check in this order:
    - `docs/architecture/adr-*.md` exists → `technical-setup`
    - `design/gdd/systems-index.md` exists → `systems-design`
    - `design/gdd/game-concept.md` exists → `concept`
+   - `prototypes/explore/*/REPORT.md` exists → `exploration` (pre-workflow, no concept yet)
+   - `prototypes/explore/` directory exists (any files) → `exploration`
    - Nothing → `concept` (fresh project)
+
+3. **If phase is `exploration`**: Return early with exploration-specific guidance.
+   This phase is not in the catalog — skip Steps 4-8 and go directly to reporting.
+
+   Read `prototypes/explore/` to find existing reports. Count how many ideas
+   have been prototyped and list their verdicts.
+
+   ```
+   ## Where You Are: Pre-Workflow Exploration
+
+   You are prototyping game ideas before committing to a development workflow.
+   No workflow is selected yet — no GDDs, no architecture, no sprint plans.
+
+   **Exploration prototypes found: [N]**
+   [List each with verdict from REPORT.md]
+
+   ### → Next up
+   **[Explore another idea]** — Run `/explore [description]` to prototype a new idea.
+   **[Or: Select a workflow]** — When you're done exploring, run
+   `/gate-check workflow-selection` to compare your prototypes and choose
+   between Hybrid (lean, iterative) and Full OCGS (formal, structured).
+
+   ### ~ Also available
+   - `/gate-check workflow-selection` — compare prototypes and choose workflow
+   - `/explore [idea]` — prototype another idea
+   ```
 
 ---
 

--- a/.opencode/skills/start/SKILL.md
+++ b/.opencode/skills/start/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: start
-description: "First-time onboarding — asks where you are, then guides you to the right workflow. No assumptions."
+description: "First-time onboarding — asks where you are, then guides you to the right workflow or to pre-workflow exploration. No assumptions."
 argument-hint: "[no arguments]"
 user-invocable: true
 allowed-tools: Read, Glob, Grep, Write, question
@@ -8,7 +8,9 @@ allowed-tools: Read, Glob, Grep, Write, question
 
 # Guided Onboarding
 
-This skill writes one file: `production/review-mode.txt` (review mode config set in Phase 3b).
+This skill writes up to two files:
+- `production/stage.txt` — set to `exploration` when user picks Path E (pre-workflow exploration).
+- `production/review-mode.txt` — review mode config (set in Phase 3b, skipped for Path E).
 
 This skill is the entry point for new users. It does NOT assume you have a game idea, an engine preference, or any prior experience. It asks first, then routes you to the right workflow.
 
@@ -40,6 +42,7 @@ This is the first thing the user sees. Use `question` with these exact options s
   - `B) Vague idea` — I have a rough theme, feeling, or genre in mind (e.g., "something with space" or "a cozy farming game") but nothing concrete.
   - `C) Clear concept` — I know the core idea — genre, basic mechanics, maybe a pitch sentence — but haven't formalized it into documents yet.
   - `D) Existing work` — I already have design docs, prototypes, code, or significant planning done. I want to organize or continue the work.
+  - `E) Multiple ideas` — I have 2-4 rough game ideas and want to prototype them quickly before committing to a specific workflow.
 
 Wait for the user's selection. Do not proceed until they respond.
 
@@ -161,11 +164,35 @@ The user needs creative exploration before anything else.
    - `/architecture-review` — bootstrap the TR requirement registry
    - `/gate-check` — validate readiness for next phase
 
+#### If E: Multiple ideas to explore
+
+The user wants to explore several rough ideas before committing to a workflow.
+
+1. Acknowledge that prototyping before committing is a good approach
+2. Briefly explain what `/explore` does (pre-workflow rapid prototyping — build throwaway prototypes in `prototypes/explore/`, produces lightweight `REPORT.md` per idea, no workflow commitment, 1-2 days per idea)
+3. Recommend running `/explore [idea-name]` for their first idea, then more for subsequent ideas
+4. Show the recommended path:
+
+   **Pre-workflow exploration:**
+   - `/explore idea-a` — build a prototype for the first idea (1-2 days)
+   - `/explore idea-b` — build a prototype for the second idea (1-2 days)
+   - `/explore idea-c` — (optional) build a prototype for the third idea
+   - Review reports in `prototypes/explore/*/REPORT.md`
+   - `/gate-check workflow-selection` — compare results and choose Hybrid or Full OCGS
+
+5. **Do NOT** ask about engine preferences, review modes, or any workflow-specific setup. The user is in pre-workflow exploration.
+
+6. Write `production/stage.txt` with value `exploration` so that `/help` and other skills know the project is in the exploration phase. Create the `production/` directory if it does not exist.
+
+   This is the only file Path E writes. No `production/review-mode.txt` is created.
+
 ---
 
 ## Phase 3b: Set Review Mode
 
-Check if `production/review-mode.txt` already exists.
+**If the user chose Path E (exploration)**: Skip this phase entirely. No review mode is needed for pre-workflow exploration. Proceed directly to Phase 4.
+
+**For all other paths**: Check if `production/review-mode.txt` already exists.
 
 **If it exists**: Read it and show the current mode — "Review mode is set to `[current]`." — then proceed to Phase 4. Do not ask again.
 
@@ -212,6 +239,8 @@ Verdict: **COMPLETE** — user oriented and handed off to next step.
 - **User picks D but project is empty**: Gently redirect — "It looks like the project is a fresh template with no artifacts yet. Would Path A or B be a better fit?"
 - **User picks A but project has code**: Mention what you found — "I noticed there's already code in `src/`. Did you mean to pick D (existing work)?"
 - **User is returning (engine configured, concept exists)**: Skip onboarding entirely — "It looks like you're already set up! Your engine is [X] and you have a game concept at `design/gdd/game-concept.md`. Review mode: `[read from production/review-mode.txt, or 'lean (default)' if missing]`. Want to pick up where you left off? Try `/sprint-plan` or just tell me what you'd like to work on."
+- **User is returning with exploration stage** (`production/stage.txt` reads `exploration`): Skip full onboarding — "It looks like you're exploring game ideas! You have [N] explore prototypes in `prototypes/explore/`. Want to run `/explore [another-idea]`, or are you ready to run `/gate-check workflow-selection` to choose a workflow?"
+- **User picks E but has existing project artifacts**: Detect if `production/stage.txt` already has a non-exploration value. If so, warn: "It looks like you already have a project in the [phase] phase. Did you mean to continue that work (Path D) instead?"
 - **User doesn't fit any option**: Let them describe their situation in their own words and adapt.
 
 ---

--- a/docs/WORKFLOW-GUIDE.md
+++ b/docs/WORKFLOW-GUIDE.md
@@ -63,6 +63,9 @@ This guided onboarding asks where you are and routes you to the right phase:
 - **Path D1** -- Existing project, few artifacts: normal flow
 - **Path D2** -- Existing project, GDDs/ADRs exist: runs `/project-stage-detect`
   then `/adopt` for brownfield migration
+- **Path E** -- Multiple ideas to explore: routes to `/explore` for rapid
+  pre-workflow prototyping, then `/gate-check workflow-selection` to choose
+  Hybrid vs. Full OCGS based on results
 
 ### Step 3: Verify Hooks Are Working
 
@@ -122,6 +125,8 @@ docs/                 # Technical documentation
   postmortems/        # Post-mortems
 tests/                # Test suites
 prototypes/           # Throwaway prototypes
+  explore/            # Pre-workflow exploration prototypes (/explore)
+  archive/            # Archived prototypes after workflow selection
 production/           # Sprint plans, milestones, releases
   sprints/
   milestones/
@@ -1462,7 +1467,7 @@ conflicts go to `producer`.
 | `/story-done` | 8-phase story completion review | 5 |
 | `/estimate` | Effort estimation with risk assessment | 4-5 |
 
-#### Reviews and Analysis (10)
+#### Reviews and Analysis (11)
 
 | Command | Purpose | Phase |
 |---------|---------|-------|
@@ -1475,6 +1480,7 @@ conflicts go to `producer`.
 | `/perf-profile` | Performance profiling workflow | 6 |
 | `/tech-debt` | Tech debt scanning and prioritization | 6 |
 | `/gate-check` | Formal phase gate with PASS/CONCERNS/FAIL | All transitions |
+| `/gate-check workflow-selection` | Choose Hybrid vs. Full after exploration | Pre-workflow |
 | `/reverse-document` | Generate design docs from existing code | Any |
 
 #### QA and Testing (9)
@@ -1512,11 +1518,13 @@ conflicts go to `producer`.
 | `/patch-notes` | Player-facing patch notes | 7 |
 | `/hotfix` | Emergency fix workflow | 7+ |
 
-#### Creative (2)
+#### Creative (4)
 
 | Command | Purpose | Phase |
 |---------|---------|-------|
+| `/explore` | Pre-workflow rapid prototyping — no workflow commitment | Pre-workflow |
 | `/prototype` | Throwaway prototype in isolated worktree | 4 |
+| `/hybrid-prototype` | Fast-lane prototype for hybrid discovery phase | Discovery |
 | `/localize` | String extraction and validation | 6-7 |
 
 #### Team Orchestration (9)
@@ -1549,7 +1557,20 @@ conflicts go to `producer`.
 7. /design-system per system (guided GDD authoring)
 ```
 
-### Workflow 2: "I have designs and want to start coding"
+### Workflow 2: "I have multiple ideas and want to explore before committing"
+
+```
+1. /start (pick Path E — multiple ideas to explore)
+2. /explore idea-a (rapid prototype, 1-2 days)
+3. /explore idea-b (rapid prototype, 1-2 days)
+4. /explore idea-c (optional, 1-2 days)
+5. Review reports in prototypes/explore/*/REPORT.md
+6. /gate-check workflow-selection (choose Hybrid vs. Full OCGS)
+7. If Hybrid: run /hybrid-prototype on the winning idea
+8. If Full: run /brainstorm [winning idea] to formalize, then /setup-engine
+```
+
+### Workflow 3: "I have designs and want to start coding"
 
 ```
 1. /design-review on each GDD (make sure they're solid)
@@ -1564,7 +1585,7 @@ conflicts go to `producer`.
 10. /story-readiness -> implement -> /story-done (story lifecycle)
 ```
 
-### Workflow 3: "I need to add a complex feature mid-production"
+### Workflow 4: "I need to add a complex feature mid-production"
 
 ```
 1. /design-system or /quick-design (depending on scope)
@@ -1576,7 +1597,7 @@ conflicts go to `producer`.
 7. /balance-check if it affects game balance
 ```
 
-### Workflow 4: "Something broke in production"
+### Workflow 5: "Something broke in production"
 
 ```
 1. /hotfix "description of the issue"
@@ -1587,7 +1608,7 @@ conflicts go to `producer`.
 6. Deploy and backport
 ```
 
-### Workflow 5: "I have an existing project and want to use this system"
+### Workflow 6: "I have an existing project and want to use this system"
 
 ```
 1. /start (choose Path D -- existing work)
@@ -1598,7 +1619,7 @@ conflicts go to `producer`.
 6. /gate-check at appropriate transition
 ```
 
-### Workflow 6: "Starting a new sprint"
+### Workflow 7: "Starting a new sprint"
 
 ```
 1. /retrospective (review last sprint)
@@ -1610,7 +1631,7 @@ conflicts go to `producer`.
 7. /sprint-status for quick progress checks
 ```
 
-### Workflow 7: "Shipping the game"
+### Workflow 8: "Shipping the game"
 
 ```
 1. /gate-check polish (verify Polish phase is complete)

--- a/docs/examples/workflow-selection-case-studies.md
+++ b/docs/examples/workflow-selection-case-studies.md
@@ -1,0 +1,221 @@
+# Workflow Selection Case Studies
+
+Three real-world scenarios demonstrating how the OCGS workflow selection
+process works in practice.
+
+---
+
+## Case Study 1: Solo Dev, First Game, 2-Month Timeline
+
+**Developer**: Liam, solo developer
+**Experience**: First commercial game, completed 2 game jams
+**Timeline**: 2 months (summer break)
+**Budget**: Self-funded, $500
+**Ideas**: 3 prototypes explored via `/explore`
+
+### Exploration Phase
+
+Liam spent 2 weeks exploring 3 ideas:
+
+```
+/explore "a platformer where you rewind time"
+    → REPORT.md: PROMISING — core mechanic feels great, but level design needs work
+    → Time spent: 2 days
+
+/explore "a farming sim with real-time crop growth"
+    → REPORT.md: NOT_VIABLE — too complex for solo dev in 2 months
+    → Time spent: 1.5 days
+
+/explore "a bullet hell with rhythm game elements"
+    → REPORT.md: NEEDS_WORK — fun concept but controls feel unresponsive
+    → Time spent: 2 days
+```
+
+### Workflow Selection
+
+```
+/gate-check workflow-selection
+    → Team size: Solo (0)
+    → Timeline: Short — under 3 months (0)
+    → Design clarity: Rough concept (0)
+    → External requirements: None (0)
+    → Experience: Small games — jams only (1)
+    → Score: 1/15 → **Hybrid**
+```
+
+### Result
+
+**Chosen workflow**: Hybrid
+**Rationale**: Solo dev, short timeline, no external requirements. Full OCGS
+would burn half his timeline in process overhead.
+
+**Liam's path:**
+1. `/brainstorm "time-rewind platformer"` — formalize the concept (1 day)
+2. `/hybrid-prototype "time-rewind platformer"` — build vertical slice (3 days)
+3. Playtest with 3 friends — fun validated
+4. `/gate-check` → enter Hybrid Production mode
+5. Build core game in 4 weeks with `gameplay-programmer` and `game-designer`
+6. Week 7-8: polish, balance, release
+
+**Outcome**: Shipped on itch.io at week 8. $200 revenue. Liam learned that
+the time-rewind mechanic is worth building a bigger game around.
+
+---
+
+## Case Study 2: Funded Team of 8, 12-Month Timeline
+
+**Team**: Stellar Forge Games, 8 people
+**Experience**: 3 shipped titles between them
+**Timeline**: 12 months
+**Budget**: $150,000 (publisher-funded)
+**Ideas**: 2 prototypes explored via `/explore`
+
+### Exploration Phase
+
+The team spent 3 weeks exploring 2 concepts:
+
+```
+/explore "co-op spaceship management with crew roles"
+    → REPORT.md: PROMISING — strong emergent gameplay, clear roles
+    → Time spent: 3 days
+
+/explore "single-player space trading with combat"
+    → REPORT.md: PROMISING — solid gameplay loop but less unique
+    → Time spent: 2 days
+```
+
+### Workflow Selection
+
+```
+/gate-check workflow-selection
+    → Team size: Medium team — 6-10 (2)
+    → Timeline: Long — 6-12 months (2)
+    → Design clarity: Some systems — core loop + 2-3 systems sketched (1)
+    → External requirements: Contractual — signed milestone deliverables (2)
+    → Experience: Experienced — shipped 1-3 commercial titles (2)
+    → Score: 9/15 → **Hybrid with upgrade path**
+```
+
+### Result
+
+**Chosen workflow**: Hybrid (with upgrade path to Full OCGS)
+**Rationale**: Score is in the mid-range. The team size and publisher
+requirements push toward Full, but the design isn't fully documented yet.
+Start Hybrid, formalize quickly, then upgrade.
+
+**The team's path:**
+1. `/brainstorm "co-op spaceship management"` — formalize concept (2 days)
+2. Write GDDs for core systems: ship management, crew roles, missions (2 weeks)
+3. Build vertical slice in 6 weeks via `/hybrid-prototype`
+4. Publisher signs off on vertical slice — milestone achieved
+5. Upgrade to Full OCGS at month 3:
+   - `/architecture-decision` × 6 (networking, save/load, state management, etc.)
+   - `/create-control-manifest` for programmer rules
+   - Enable full QA pipeline
+6. Production sprints (months 4-10) with `/team-combat`, `/team-narrative`, etc.
+7. Polish months 11-12 with `/perf-profile`, playtesting, localization
+
+**Outcome**: On track for milestone delivery. The upgrade from Hybrid to Full
+at month 3 was smooth because the team had already documented GDDs and ADRs.
+The publisher receives monthly milestone reports with `/milestone-review`.
+
+---
+
+## Case Study 3: Solo-to-Team, Scope Creep, 4-Month Timeline
+
+**Developer**: Priya, solo founder → building a team
+**Experience**: Shipped 2 commercial mobile games
+**Timeline**: Originally 4 months, scope inflated to 8 months
+**Ideas**: 1 concept, started building immediately without exploration
+
+### The Problem
+
+Priya started building her game directly — no `/explore`, no workflow selection.
+By month 3, she had:
+- A partially working prototype in `src/` (mixed prototype and production code)
+- 3 friends offering to help (team growing to 4)
+- An exploding scope (originally a simple puzzle game, now with RPG systems)
+- No GDDs, no ADRs, no sprint planning
+
+### Workflow Selection (Retrospective)
+
+If Priya had run `/gate-check workflow-selection` before starting:
+
+```
+/gate-check workflow-selection
+    → Team size at start: Solo (0), now growing to 4
+    → Timeline: Originally 4mo, now 8mo
+    → Design clarity: Rough concept — "puzzle RPG" (0)
+    → External requirements: None (0)
+    → Experience: Experienced — 2 shipped titles (2)
+    → Score if run at start: 2/15 → **Hybrid**
+    → Score if run now with team: Would signal upgrade needed
+```
+
+### Recovery Path
+
+Priya runs `/gate-check workflow-selection` at month 3 (current state):
+
+```
+    → Team size: Small team — 2-5 (1)
+    → Timeline: Medium — 3-6 months, trending to 8 (2)
+    → Design clarity: Some systems — core + 2 RPG systems (1)
+    → External requirements: None (0)
+    → Experience: Experienced — 2 shipped (2)
+    → Score: 6/15 → **Hybrid with upgrade path**
+```
+
+**Recommended path:**
+1. **Stop coding.** Run `/project-stage-detect` + `/adopt` to assess what exists
+2. **Separate prototype code from production code**:
+   - Move `src/` code to `prototypes/archive/mvp/`
+   - Start fresh `src/` with proper structure
+3. **Formalize the design**:
+   - `/brainstorm "puzzle RPG with crafting"` — get pillars down
+   - `/design-system puzzle-core` — write a proper GDD
+   - `/design-system crafting` — optional, defer if not MVP
+4. **Upgrade to Full OCGS** (score 6 and growing team signal this):
+   - `/create-architecture` — data flow between puzzle and RPG systems
+   - `/architecture-decision` × 3-4 core decisions
+   - `/create-control-manifest` for the new team members
+5. **Onboard the team**:
+   - `/onboard gameplay-programmer` — new team member orientation
+   - `/sprint-plan new` — first sprint with realistic scope
+
+**Upgrade trigger**: Team growing beyond solo, scope inflating, timeline
+extending. The workflow selection at month 3 correctly identifies the need
+for more structure, even though it started as a solo Hybrid project.
+
+### Lessons
+
+- **Prototype before committing**: Even experienced devs benefit from `/explore`
+- **Re-run workflow selection when conditions change**: Team size, timeline,
+  and scope are all dynamic
+- **It's never too late**: Priya caught the problem at month 3 instead of
+  month 8. The recovery path is clear even mid-project.
+
+---
+
+## Upgrade Trigger Reference
+
+When any of these conditions become true, re-run `/gate-check workflow-selection`
+to reassess:
+
+| Trigger | What changed | New recommendation |
+|---------|-------------|-------------------|
+| Team grows from 1 → 3+ | Score +1 to +2 | Hybrid → Hybrid with upgrade |
+| Team grows from 3 → 6+ | Score +1 to +2 | Hybrid → Full OCGS |
+| Timeline extends past 6 months | Score +1 to +2 | Hybrid → Full OCGS |
+| Publisher signs on | Score +2 | Hybrid → Full OCGS |
+| Design scope doubles | Score +1 | Stay hybrid, but formalize |
+| Need multiplayer or live ops | +1 per requirement | Push toward Full OCGS |
+| First playtest fails | No score change | Rerun `/explore`, don't upgrade |
+| Team consistently misses sprints | No score change | Upgrade to Full for process help |
+
+---
+
+## See Also
+
+- `docs/hybrid-workflow.md` — Hybrid workflow overview and comparison
+- `docs/workflow-transitions.md` — How to transition between workflows
+- `.opencode/skills/gate-check/SKILL.md` — Workflow Selection gate implementation

--- a/docs/hybrid-workflow.md
+++ b/docs/hybrid-workflow.md
@@ -10,6 +10,10 @@ This document defines a pragmatic hybrid workflow that balances **creative agili
 
 **Not sure which workflow to use?** Run `/explore` to rapidly prototype 2-4 ideas with zero workflow commitment, then use `/gate-check workflow-selection` to choose the right workflow based on your results. See [Pre-Workflow Exploration](#pre-workflow-exploration) below.
 
+**See real-world examples**: The [Workflow Selection Case Studies](examples/workflow-selection-case-studies.md)
+document walks through three scenarios — solo dev, funded team, and scope
+recovery — showing how the workflow selection process works in practice.
+
 ---
 
 ## Two-Phase Model
@@ -142,12 +146,16 @@ A new skill/command that shortcuts the path to a playable prototype:
 
 ## When to Switch to Full OCGS
 
-Switch back to the **full 49-agent framework** if any of these become true:
+Switch to the **full 49-agent framework** if any of these become true:
 - Team grows beyond 5 people
 - Project timeline exceeds 6 months
 - Multiple features need parallel development
 - You need live ops, analytics, or multiplayer
 - Funding/publisher requires formal process
+
+For a detailed upgrade trigger reference with scoring and case studies,
+see [Upgrade Trigger Reference](examples/workflow-selection-case-studies.md#upgrade-trigger-reference)
+in the Workflow Selection Case Studies.
 
 ---
 

--- a/docs/hybrid-workflow.md
+++ b/docs/hybrid-workflow.md
@@ -6,7 +6,9 @@ This document defines a pragmatic hybrid workflow that balances **creative agili
 
 **When to use this workflow**: Small teams, unknown designs, short timelines (weeks to a few months), prototypes that may be pivoted or killed.
 
-**When to use the full OCGS workflow**: Large teams (5–15+), known designs, long timelines (6+ months), funded projects with publisher requirements.
+**When to use the full OCGS workflow**: Large teams (5-15+), known designs, long timelines (6+ months), funded projects with publisher requirements.
+
+**Not sure which workflow to use?** Run `/explore` to rapidly prototype 2-4 ideas with zero workflow commitment, then use `/gate-check workflow-selection` to choose the right workflow based on your results. See [Pre-Workflow Exploration](#pre-workflow-exploration) below.
 
 ---
 
@@ -158,6 +160,57 @@ Switch back to the **full 49-agent framework** if any of these become true:
 | Coordination (late) | Excellent | Good |
 | Team size | 5–15 | 1–5 |
 | Best for | Known game, funded, long timeline | Unknown game, indie, iterating |
+
+---
+
+## Pre-Workflow Exploration
+
+Before committing to Hybrid or Full OCGS, you can explore multiple ideas rapidly with **zero workflow commitment**.
+
+### The `/explore` Skill
+
+```
+/explore "a farming sim where crops grow in real time"
+/explore "a roguelike where weapons break permanently"
+/explore "a narrative puzzle game with time loops"
+```
+
+**What `/explore` does:**
+- Builds a throwaway prototype in `prototypes/explore/[idea-name]/`
+- Time-boxed to 1-2 days per idea
+- Produces a lightweight `REPORT.md` with a verdict: **PROMISING / NEEDS_WORK / NOT_VIABLE / TIMEOUT**
+- Does NOT create `production/stage.txt`, `production/review-mode.txt`, or any workflow artifacts
+- Does NOT require choosing Hybrid vs. Full upfront
+
+**When to use it:**
+- You have 2-4 rough ideas and want to compare them before committing
+- You are not sure if your concept is fun, feasible, or correctly scoped
+- You want to avoid formal process overhead until you know what you're making
+
+**Exploration workflow:**
+
+```
+/explore idea-a          → prototypes/explore/idea-a/REPORT.md
+/explore idea-b          → prototypes/explore/idea-b/REPORT.md
+/explore idea-c          → prototypes/explore/idea-c/REPORT.md
+
+/gate-check workflow-selection
+    → Compare prototypes
+    → Choose Hybrid or Full
+    → Set workflow mode and stage
+```
+
+### How `/explore` Differs from Other Prototype Skills
+
+| Aspect | `/explore` | `/hybrid-prototype` | `/prototype` (Full OCGS) |
+|--------|-----------|---------------------|--------------------------|
+| **Workflow stage** | Pre-workflow | Hybrid Discovery | Full OCGS Pre-Production |
+| **Workflow commitment** | None | Hybrid | Full OCGS |
+| **Creates stage.txt?** | No | Yes | Yes |
+| **Time budget** | 1-2 days | 1-3 days | 1-3 days |
+| **Report** | Lightweight REPORT.md | DECISION.md | Formal REPORT.md |
+| **Next step** | Workflow selection | Begin GDD/architecture | Begin GDD/architecture |
+| **Agents** | `prototyper` only | 4 core roles | All tiers |
 
 ---
 


### PR DESCRIPTION
## Summary
Adds three real-world workflow selection case studies and cross-references from the hybrid workflow documentation.

## Changes
- \docs/examples/workflow-selection-case-studies.md\:
  - Case Study 1: Solo dev, first game, 2-month timeline → Hybrid
  - Case Study 2: Funded team of 8, 12-month timeline → Hybrid with upgrade
  - Case Study 3: Solo-to-team scope recovery → retrospective selection
  - Upgrade trigger reference table with scoring guidance
- \docs/hybrid-workflow.md\: cross-references to case studies
- Expanded upgrade triggers with link to detailed reference

Closes #45