### PR TITLE
docs: Artifact promotion rules for prototype-to-production transitions

### DIFF
--- a/.opencode/commands/explore.md
+++ b/.opencode/commands/explore.md
@@ -1,0 +1,8 @@
+---
+name: explore
+description: "Pre-workflow rapid prototyping for exploring multiple game ideas"
+skill: explore
+category: prototyping
+---
+
+Invokes `/explore` skill.

--- a/.opencode/skills/explore/SKILL.md
+++ b/.opencode/skills/explore/SKILL.md
@@ -1,0 +1,218 @@
+---
+name: explore
+description: "Pre-workflow rapid prototyping for exploring multiple game ideas before committing to a development workflow. Produces lightweight reports with no workflow commitment."
+argument-hint: "[concept-description]"
+user-invocable: true
+allowed-tools: Read, Glob, Grep, Write, Edit, Bash, Task
+agent: prototyper
+isolation: worktree
+---
+
+## Overview
+
+This skill is the **pre-workflow exploration lane**. Use it when you have one or more rough game ideas and want to validate them before choosing between the Hybrid workflow (lean, iterative) or the Full OCGS workflow (formal, structured).
+
+**When to use `/explore`:**
+- You have 2-4 rough ideas and want to feel them out before committing
+- You are not sure if your concept is fun, feasible, or scoped correctly
+- You want to avoid formal process overhead until you know what you're making
+
+**When NOT to use `/explore`:**
+- You already know your game and are ready to build → use `/start` directly
+- You are in the middle of production → use `/prototype` or `/hybrid-prototype`
+- You need a formal vertical slice → use `/prototype` within the full workflow
+
+**Key properties:**
+- **No workflow commitment**: Does not create `production/stage.txt`, `production/review-mode.txt`, or any production artifacts
+- **No process overhead**: No GDDs, no ADRs, no architecture, no sprint plans
+- **Time-boxed**: 1-2 days per idea maximum
+- **Isolated**: All work lives in `prototypes/explore/[idea-name]/`
+- **Composable**: Run it multiple times for multiple ideas, then compare results
+
+**Agents involved**: `prototyper` only. No director reviews, no multi-tier coordination.
+
+---
+
+## Phase 1: Define the Question (5 minutes)
+
+Read the concept description from the argument. State the **one core question** this prototype must answer. If the concept is vague, ask the user to clarify before proceeding.
+
+Examples of good questions:
+- "Does the core loop of harvesting + crafting feel satisfying for 10 minutes?"
+- "Is the combat pace too slow or too frantic with 3 enemy types?"
+- "Does the movement mechanic make exploration feel good, or tedious?"
+
+Bad question: "Is this game fun?" (Too broad. Narrow it down to one mechanic or feeling.)
+
+**Ask the user**: "The core question for this prototype is: **[question]**. Proceed?"
+
+---
+
+## Phase 2: Plan (15 minutes)
+
+Define the minimum viable prototype in 3-5 bullet points:
+
+- What is the absolute minimum code to answer the question?
+- What can be hardcoded / placeholder / skipped?
+- What is the success criteria? (e.g., "Player completes 3 crafting cycles without confusion")
+- What is the time budget? (default: 1-2 days)
+
+**Present the plan to the user and ask for confirmation.**
+
+If the user is exploring multiple ideas, remind them: "This is idea **[N]** of your exploration. Keep the scope tight so you can compare fairly."
+
+---
+
+## Phase 3: Build (1-2 days)
+
+**Ask**: "May I create the prototype directory at `prototypes/explore/[idea-name]/` and begin implementation?"
+
+If yes, create the directory. Every file must begin with:
+
+```
+// EXPLORE PROTOTYPE - NOT FOR PRODUCTION
+// Question: [Core question being tested]
+// Date: [Current date]
+// Workflow: pre-workflow exploration (no workflow committed)
+```
+
+**Rules for explore prototype code**:
+- Hardcode values freely
+- Use placeholder assets (colored squares, simple shapes, primitive meshes)
+- Skip error handling, polish, and architecture
+- Use the simplest approach that works
+- Copy code rather than importing from production
+- NEVER import from `src/` — explore prototypes are fully isolated
+- NEVER create files in `production/`, `design/`, `docs/architecture/`, or `src/`
+
+**Run the prototype** as you build. Test continuously. Fix blockers, but don't polish.
+
+If the build exceeds 2 days, **stop and report**. Exploration prototypes that drag on lose their purpose. Either reduce scope or mark as TIMEOUT.
+
+---
+
+## Phase 4: Playtest (1-2 hours)
+
+Play the prototype yourself. Then ask the user to play it. Collect observations:
+
+- What worked?
+- What felt bad?
+- Did it answer the core question?
+- Any surprising discoveries?
+- How long did it take to build?
+
+**Document findings informally** — a bulleted list is fine at this stage.
+
+---
+
+## Phase 5: Generate Report (15 minutes)
+
+Draft a lightweight report:
+
+```markdown
+# Explore Report: [Idea Name]
+
+## Question
+[The core question this prototype set out to answer]
+
+## Approach
+[What was built, time spent, shortcuts taken]
+
+## Result
+[What actually happened — specific observations]
+
+## Verdict
+[PROMISING / NEEDS_WORK / NOT_VIABLE / TIMEOUT]
+
+- **PROMISING**: The core idea works. Worth developing further.
+- **NEEDS_WORK**: The idea has potential but needs significant adjustment.
+- **NOT_VIABLE**: The idea does not work as conceived. Do not pursue.
+- **TIMEOUT**: The prototype could not be completed in the timebox. Scope was too large or the idea is too complex to explore quickly.
+
+## Reasoning
+[One paragraph explaining the verdict with evidence]
+
+## Surprises
+[Any unexpected findings that affect this or other ideas]
+
+## Estimated Production Effort
+[Rough guess: small (weeks) / medium (months) / large (6+ months)]
+```
+
+**Ask**: "May I write this report to `prototypes/explore/[idea-name]/REPORT.md`?"
+
+---
+
+## Phase 6: Next Steps
+
+After the report is written, present the user's options:
+
+**If the user has more ideas to explore:**
+> "Idea **[current idea]** is documented. You have **[N]** more ideas to explore. Ready to run `/explore [next-idea]`?"
+
+**If the user is done exploring:**
+> "Exploration complete. You have **[N]** reports in `prototypes/explore/`:
+> - `[idea-1]`: PROMISING
+> - `[idea-2]`: NOT_VIABLE
+> - `[idea-3]`: NEEDS_WORK
+>
+> **Next step**: Run `/gate-check workflow-selection` to compare your prototypes and choose between the Hybrid and Full OCGS workflows.
+>
+> Or, if you want to refine one idea first: `/explore [revised-concept]` to iterate."
+
+**Do NOT**:
+- Suggest `/design-system`, `/create-architecture`, or any production-phase skill
+- Create `production/stage.txt`
+- Set a review mode
+- Route to `/brainstorm` unless the user explicitly asks for ideation help
+
+---
+
+## Phase 7: Summary
+
+Output a summary to the user:
+- Idea name and core question
+- Verdict (PROMISING / NEEDS_WORK / NOT_VIABLE / TIMEOUT)
+- Location of the report
+- Clear next step (explore another idea, or workflow selection)
+
+Verdict: **COMPLETE** — exploration prototype finished. No workflow committed.
+
+---
+
+## Constraints
+
+- Prototype code must NEVER import from production source files
+- Production code must NEVER import from prototype directories
+- If an idea is later productionized, rewrite from scratch — do not refactor explore prototype code
+- Timebox strictly: 1-2 days per idea. If it's not testable after 2 days, verdict is TIMEOUT
+- Keep the question narrow — one prototype, one question
+- No workflow artifacts: do not touch `production/`, `design/gdd/`, `docs/architecture/`, or `src/`
+- No review mode gates, no director reviews, no multi-agent coordination
+- **Workflow isolation**: This skill explicitly bypasses `production/review-mode.txt` and `production/stage.txt`. Any existing workflow state is ignored during exploration.
+
+---
+
+## Comparison with Other Prototype Skills
+
+| Aspect | `/explore` | `/prototype` (Full OCGS) | `/hybrid-prototype` (Hybrid) |
+|--------|-----------|--------------------------|------------------------------|
+| **Workflow stage** | Pre-workflow | Phase 4 (Pre-Production) | Phase 1 (Discovery) |
+| **Workflow commitment** | None | Full OCGS | Hybrid |
+| **Creates stage.txt?** | No | Yes | Yes (hybrid stage) |
+| **Review mode gates** | None | Solo / Lean / Full | None |
+| **Report format** | Lightweight `REPORT.md` | Formal `REPORT.md` | Lightweight `DECISION.md` |
+| **Directory** | `prototypes/explore/` | `prototypes/[name]/` | `prototypes/[name]/` |
+| **Next step on success** | `/gate-check workflow-selection` | `/design-system` or `/architecture-decision` | `/design-system` or `/create-architecture` |
+| **Time budget** | 1-2 days | 1-3 days | 1-3 days |
+| **Agents involved** | `prototyper` only | All tiers | 4 core roles |
+| **Designed for** | Comparing multiple ideas | Validating a known concept | Finding the fun in one idea |
+
+---
+
+## Recommended Next Steps
+
+- **If exploring more ideas**: Run `/explore [next-concept]` for the next idea
+- **If done exploring**: Run `/gate-check workflow-selection` to choose Hybrid vs. Full OCGS
+- **If one idea needs refinement**: Run `/explore [revised-concept]` with adjusted scope
+- **If ready to commit to a workflow**: Run `/start` after workflow selection to begin formal onboarding

--- a/.opencode/skills/help/SKILL.md
+++ b/.opencode/skills/help/SKILL.md
@@ -63,6 +63,7 @@ Check in this order:
    - "Production" → `production`
    - "Polish" → `polish`
    - "Release" → `release`
+   - "exploration" → `exploration` (pre-workflow, not in catalog)
 
 2. **If stage.txt is missing**, infer phase from artifacts (most-advanced match wins):
    - `src/` has 10+ source files → `production`
@@ -70,7 +71,35 @@ Check in this order:
    - `docs/architecture/adr-*.md` exists → `technical-setup`
    - `design/gdd/systems-index.md` exists → `systems-design`
    - `design/gdd/game-concept.md` exists → `concept`
+   - `prototypes/explore/*/REPORT.md` exists → `exploration` (pre-workflow, no concept yet)
+   - `prototypes/explore/` directory exists (any files) → `exploration`
    - Nothing → `concept` (fresh project)
+
+3. **If phase is `exploration`**: Return early with exploration-specific guidance.
+   This phase is not in the catalog — skip Steps 4-8 and go directly to reporting.
+
+   Read `prototypes/explore/` to find existing reports. Count how many ideas
+   have been prototyped and list their verdicts.
+
+   ```
+   ## Where You Are: Pre-Workflow Exploration
+
+   You are prototyping game ideas before committing to a development workflow.
+   No workflow is selected yet — no GDDs, no architecture, no sprint plans.
+
+   **Exploration prototypes found: [N]**
+   [List each with verdict from REPORT.md]
+
+   ### → Next up
+   **[Explore another idea]** — Run `/explore [description]` to prototype a new idea.
+   **[Or: Select a workflow]** — When you're done exploring, run
+   `/gate-check workflow-selection` to compare your prototypes and choose
+   between Hybrid (lean, iterative) and Full OCGS (formal, structured).
+
+   ### ~ Also available
+   - `/gate-check workflow-selection` — compare prototypes and choose workflow
+   - `/explore [idea]` — prototype another idea
+   ```
 
 ---
 

--- a/.opencode/skills/start/SKILL.md
+++ b/.opencode/skills/start/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: start
-description: "First-time onboarding — asks where you are, then guides you to the right workflow. No assumptions."
+description: "First-time onboarding — asks where you are, then guides you to the right workflow or to pre-workflow exploration. No assumptions."
 argument-hint: "[no arguments]"
 user-invocable: true
 allowed-tools: Read, Glob, Grep, Write, question
@@ -8,7 +8,9 @@ allowed-tools: Read, Glob, Grep, Write, question
 
 # Guided Onboarding
 
-This skill writes one file: `production/review-mode.txt` (review mode config set in Phase 3b).
+This skill writes up to two files:
+- `production/stage.txt` — set to `exploration` when user picks Path E (pre-workflow exploration).
+- `production/review-mode.txt` — review mode config (set in Phase 3b, skipped for Path E).
 
 This skill is the entry point for new users. It does NOT assume you have a game idea, an engine preference, or any prior experience. It asks first, then routes you to the right workflow.
 
@@ -40,6 +42,7 @@ This is the first thing the user sees. Use `question` with these exact options s
   - `B) Vague idea` — I have a rough theme, feeling, or genre in mind (e.g., "something with space" or "a cozy farming game") but nothing concrete.
   - `C) Clear concept` — I know the core idea — genre, basic mechanics, maybe a pitch sentence — but haven't formalized it into documents yet.
   - `D) Existing work` — I already have design docs, prototypes, code, or significant planning done. I want to organize or continue the work.
+  - `E) Multiple ideas` — I have 2-4 rough game ideas and want to prototype them quickly before committing to a specific workflow.
 
 Wait for the user's selection. Do not proceed until they respond.
 
@@ -161,11 +164,35 @@ The user needs creative exploration before anything else.
    - `/architecture-review` — bootstrap the TR requirement registry
    - `/gate-check` — validate readiness for next phase
 
+#### If E: Multiple ideas to explore
+
+The user wants to explore several rough ideas before committing to a workflow.
+
+1. Acknowledge that prototyping before committing is a good approach
+2. Briefly explain what `/explore` does (pre-workflow rapid prototyping — build throwaway prototypes in `prototypes/explore/`, produces lightweight `REPORT.md` per idea, no workflow commitment, 1-2 days per idea)
+3. Recommend running `/explore [idea-name]` for their first idea, then more for subsequent ideas
+4. Show the recommended path:
+
+   **Pre-workflow exploration:**
+   - `/explore idea-a` — build a prototype for the first idea (1-2 days)
+   - `/explore idea-b` — build a prototype for the second idea (1-2 days)
+   - `/explore idea-c` — (optional) build a prototype for the third idea
+   - Review reports in `prototypes/explore/*/REPORT.md`
+   - `/gate-check workflow-selection` — compare results and choose Hybrid or Full OCGS
+
+5. **Do NOT** ask about engine preferences, review modes, or any workflow-specific setup. The user is in pre-workflow exploration.
+
+6. Write `production/stage.txt` with value `exploration` so that `/help` and other skills know the project is in the exploration phase. Create the `production/` directory if it does not exist.
+
+   This is the only file Path E writes. No `production/review-mode.txt` is created.
+
 ---
 
 ## Phase 3b: Set Review Mode
 
-Check if `production/review-mode.txt` already exists.
+**If the user chose Path E (exploration)**: Skip this phase entirely. No review mode is needed for pre-workflow exploration. Proceed directly to Phase 4.
+
+**For all other paths**: Check if `production/review-mode.txt` already exists.
 
 **If it exists**: Read it and show the current mode — "Review mode is set to `[current]`." — then proceed to Phase 4. Do not ask again.
 
@@ -212,6 +239,8 @@ Verdict: **COMPLETE** — user oriented and handed off to next step.
 - **User picks D but project is empty**: Gently redirect — "It looks like the project is a fresh template with no artifacts yet. Would Path A or B be a better fit?"
 - **User picks A but project has code**: Mention what you found — "I noticed there's already code in `src/`. Did you mean to pick D (existing work)?"
 - **User is returning (engine configured, concept exists)**: Skip onboarding entirely — "It looks like you're already set up! Your engine is [X] and you have a game concept at `design/gdd/game-concept.md`. Review mode: `[read from production/review-mode.txt, or 'lean (default)' if missing]`. Want to pick up where you left off? Try `/sprint-plan` or just tell me what you'd like to work on."
+- **User is returning with exploration stage** (`production/stage.txt` reads `exploration`): Skip full onboarding — "It looks like you're exploring game ideas! You have [N] explore prototypes in `prototypes/explore/`. Want to run `/explore [another-idea]`, or are you ready to run `/gate-check workflow-selection` to choose a workflow?"
+- **User picks E but has existing project artifacts**: Detect if `production/stage.txt` already has a non-exploration value. If so, warn: "It looks like you already have a project in the [phase] phase. Did you mean to continue that work (Path D) instead?"
 - **User doesn't fit any option**: Let them describe their situation in their own words and adapt.
 
 ---

--- a/docs/WORKFLOW-GUIDE.md
+++ b/docs/WORKFLOW-GUIDE.md
@@ -63,6 +63,9 @@ This guided onboarding asks where you are and routes you to the right phase:
 - **Path D1** -- Existing project, few artifacts: normal flow
 - **Path D2** -- Existing project, GDDs/ADRs exist: runs `/project-stage-detect`
   then `/adopt` for brownfield migration
+- **Path E** -- Multiple ideas to explore: routes to `/explore` for rapid
+  pre-workflow prototyping, then `/gate-check workflow-selection` to choose
+  Hybrid vs. Full OCGS based on results
 
 ### Step 3: Verify Hooks Are Working
 
@@ -122,6 +125,8 @@ docs/                 # Technical documentation
   postmortems/        # Post-mortems
 tests/                # Test suites
 prototypes/           # Throwaway prototypes
+  explore/            # Pre-workflow exploration prototypes (/explore)
+  archive/            # Archived prototypes after workflow selection
 production/           # Sprint plans, milestones, releases
   sprints/
   milestones/
@@ -1462,7 +1467,7 @@ conflicts go to `producer`.
 | `/story-done` | 8-phase story completion review | 5 |
 | `/estimate` | Effort estimation with risk assessment | 4-5 |
 
-#### Reviews and Analysis (10)
+#### Reviews and Analysis (11)
 
 | Command | Purpose | Phase |
 |---------|---------|-------|
@@ -1475,6 +1480,7 @@ conflicts go to `producer`.
 | `/perf-profile` | Performance profiling workflow | 6 |
 | `/tech-debt` | Tech debt scanning and prioritization | 6 |
 | `/gate-check` | Formal phase gate with PASS/CONCERNS/FAIL | All transitions |
+| `/gate-check workflow-selection` | Choose Hybrid vs. Full after exploration | Pre-workflow |
 | `/reverse-document` | Generate design docs from existing code | Any |
 
 #### QA and Testing (9)
@@ -1512,11 +1518,13 @@ conflicts go to `producer`.
 | `/patch-notes` | Player-facing patch notes | 7 |
 | `/hotfix` | Emergency fix workflow | 7+ |
 
-#### Creative (2)
+#### Creative (4)
 
 | Command | Purpose | Phase |
 |---------|---------|-------|
+| `/explore` | Pre-workflow rapid prototyping — no workflow commitment | Pre-workflow |
 | `/prototype` | Throwaway prototype in isolated worktree | 4 |
+| `/hybrid-prototype` | Fast-lane prototype for hybrid discovery phase | Discovery |
 | `/localize` | String extraction and validation | 6-7 |
 
 #### Team Orchestration (9)
@@ -1549,7 +1557,20 @@ conflicts go to `producer`.
 7. /design-system per system (guided GDD authoring)
 ```
 
-### Workflow 2: "I have designs and want to start coding"
+### Workflow 2: "I have multiple ideas and want to explore before committing"
+
+```
+1. /start (pick Path E — multiple ideas to explore)
+2. /explore idea-a (rapid prototype, 1-2 days)
+3. /explore idea-b (rapid prototype, 1-2 days)
+4. /explore idea-c (optional, 1-2 days)
+5. Review reports in prototypes/explore/*/REPORT.md
+6. /gate-check workflow-selection (choose Hybrid vs. Full OCGS)
+7. If Hybrid: run /hybrid-prototype on the winning idea
+8. If Full: run /brainstorm [winning idea] to formalize, then /setup-engine
+```
+
+### Workflow 3: "I have designs and want to start coding"
 
 ```
 1. /design-review on each GDD (make sure they're solid)
@@ -1564,7 +1585,7 @@ conflicts go to `producer`.
 10. /story-readiness -> implement -> /story-done (story lifecycle)
 ```
 
-### Workflow 3: "I need to add a complex feature mid-production"
+### Workflow 4: "I need to add a complex feature mid-production"
 
 ```
 1. /design-system or /quick-design (depending on scope)
@@ -1576,7 +1597,7 @@ conflicts go to `producer`.
 7. /balance-check if it affects game balance
 ```
 
-### Workflow 4: "Something broke in production"
+### Workflow 5: "Something broke in production"
 
 ```
 1. /hotfix "description of the issue"
@@ -1587,7 +1608,7 @@ conflicts go to `producer`.
 6. Deploy and backport
 ```
 
-### Workflow 5: "I have an existing project and want to use this system"
+### Workflow 6: "I have an existing project and want to use this system"
 
 ```
 1. /start (choose Path D -- existing work)
@@ -1598,7 +1619,7 @@ conflicts go to `producer`.
 6. /gate-check at appropriate transition
 ```
 
-### Workflow 6: "Starting a new sprint"
+### Workflow 7: "Starting a new sprint"
 
 ```
 1. /retrospective (review last sprint)
@@ -1610,7 +1631,7 @@ conflicts go to `producer`.
 7. /sprint-status for quick progress checks
 ```
 
-### Workflow 7: "Shipping the game"
+### Workflow 8: "Shipping the game"
 
 ```
 1. /gate-check polish (verify Polish phase is complete)

--- a/docs/WORKFLOW-GUIDE.md
+++ b/docs/WORKFLOW-GUIDE.md
@@ -65,7 +65,8 @@ This guided onboarding asks where you are and routes you to the right phase:
   then `/adopt` for brownfield migration
 - **Path E** -- Multiple ideas to explore: routes to `/explore` for rapid
   pre-workflow prototyping, then `/gate-check workflow-selection` to choose
-  Hybrid vs. Full OCGS based on results
+  Hybrid vs. Full OCGS based on results. See [Workflow Transitions Guide](workflow-transitions.md)
+  for artifact promotion rules when moving from exploration into either workflow.
 
 ### Step 3: Verify Hooks Are Working
 

--- a/docs/hybrid-workflow.md
+++ b/docs/hybrid-workflow.md
@@ -6,7 +6,9 @@ This document defines a pragmatic hybrid workflow that balances **creative agili
 
 **When to use this workflow**: Small teams, unknown designs, short timelines (weeks to a few months), prototypes that may be pivoted or killed.
 
-**When to use the full OCGS workflow**: Large teams (5–15+), known designs, long timelines (6+ months), funded projects with publisher requirements.
+**When to use the full OCGS workflow**: Large teams (5-15+), known designs, long timelines (6+ months), funded projects with publisher requirements.
+
+**Not sure which workflow to use?** Run `/explore` to rapidly prototype 2-4 ideas with zero workflow commitment, then use `/gate-check workflow-selection` to choose the right workflow based on your results. See [Pre-Workflow Exploration](#pre-workflow-exploration) below.
 
 ---
 
@@ -158,6 +160,57 @@ Switch back to the **full 49-agent framework** if any of these become true:
 | Coordination (late) | Excellent | Good |
 | Team size | 5–15 | 1–5 |
 | Best for | Known game, funded, long timeline | Unknown game, indie, iterating |
+
+---
+
+## Pre-Workflow Exploration
+
+Before committing to Hybrid or Full OCGS, you can explore multiple ideas rapidly with **zero workflow commitment**.
+
+### The `/explore` Skill
+
+```
+/explore "a farming sim where crops grow in real time"
+/explore "a roguelike where weapons break permanently"
+/explore "a narrative puzzle game with time loops"
+```
+
+**What `/explore` does:**
+- Builds a throwaway prototype in `prototypes/explore/[idea-name]/`
+- Time-boxed to 1-2 days per idea
+- Produces a lightweight `REPORT.md` with a verdict: **PROMISING / NEEDS_WORK / NOT_VIABLE / TIMEOUT**
+- Does NOT create `production/stage.txt`, `production/review-mode.txt`, or any workflow artifacts
+- Does NOT require choosing Hybrid vs. Full upfront
+
+**When to use it:**
+- You have 2-4 rough ideas and want to compare them before committing
+- You are not sure if your concept is fun, feasible, or correctly scoped
+- You want to avoid formal process overhead until you know what you're making
+
+**Exploration workflow:**
+
+```
+/explore idea-a          → prototypes/explore/idea-a/REPORT.md
+/explore idea-b          → prototypes/explore/idea-b/REPORT.md
+/explore idea-c          → prototypes/explore/idea-c/REPORT.md
+
+/gate-check workflow-selection
+    → Compare prototypes
+    → Choose Hybrid or Full
+    → Set workflow mode and stage
+```
+
+### How `/explore` Differs from Other Prototype Skills
+
+| Aspect | `/explore` | `/hybrid-prototype` | `/prototype` (Full OCGS) |
+|--------|-----------|---------------------|--------------------------|
+| **Workflow stage** | Pre-workflow | Hybrid Discovery | Full OCGS Pre-Production |
+| **Workflow commitment** | None | Hybrid | Full OCGS |
+| **Creates stage.txt?** | No | Yes | Yes |
+| **Time budget** | 1-2 days | 1-3 days | 1-3 days |
+| **Report** | Lightweight REPORT.md | DECISION.md | Formal REPORT.md |
+| **Next step** | Workflow selection | Begin GDD/architecture | Begin GDD/architecture |
+| **Agents** | `prototyper` only | 4 core roles | All tiers |
 
 ---
 

--- a/docs/hybrid-workflow.md
+++ b/docs/hybrid-workflow.md
@@ -225,6 +225,10 @@ If a project starts with the hybrid workflow and later needs the full OCGS frame
 5. **Switch to `src/`** with full coding standards.
 6. **Enable all quality gates** from the full framework.
 
+For the full step-by-step guide including artifact promotion rules and what
+to keep vs. rewrite, see [Path C: Hybrid Discovery → Full OCGS](workflow-transitions.md#path-c-hybrid-discovery--full-ocgs)
+in the Workflow Transition Guide.
+
 ---
 
 ## Notes

--- a/docs/workflow-transitions.md
+++ b/docs/workflow-transitions.md
@@ -1,0 +1,273 @@
+# Workflow Transition Guide
+
+This document defines how to transition between development modes in the OCGS
+framework. It covers four paths:
+
+- **[Path A](#path-a-explore--hybrid)**: Pre-workflow `/explore` → Hybrid workflow
+- **[Path B](#path-b-explore--full-ocgs)**: Pre-workflow `/explore` → Full OCGS
+- **[Path C](#path-c-hybrid-discovery--full-ocgs)**: Hybrid Discovery → Full OCGS
+- **[Path D](#path-d-full-ocgs-prototype--production)**: Full OCGS `/prototype` → Production
+
+---
+
+## Core Principle: Code Never Promotes
+
+**The number one rule across ALL transition paths:**
+
+> Prototype code is never refactored into production code.
+> Production code never imports from prototype directories.
+
+This is not negotiable. Prototype code is written under relaxed standards:
+hardcoded values, no error handling, no architecture. Moving it into production
+creates technical debt that costs more to fix than a clean rewrite. Every path
+below follows this rule.
+
+**What promotes:**
+- Design insights and findings
+- Balance data that was empirically validated
+- Asset ideas (concept art, mood boards, placeholder specs)
+- Acceptance criteria that were validated in playtesting
+
+**What gets rewritten from scratch:**
+- All source code
+- Scene/level files
+- Configuration files (rewritten with production structure)
+- Asset placeholders (replaced with production-quality assets)
+
+---
+
+## Path A: Explore → Hybrid
+
+**Trigger**: `/gate-check workflow-selection` returns Hybrid recommendation
+and user confirms.
+
+**Starting artifacts**: One or more reports in `prototypes/explore/*/REPORT.md`
+with PROMISING verdicts.
+
+### Steps
+
+1. **Archive exploration prototypes**
+   ```
+   prototypes/explore/  →  prototypes/archive/explore/[date]/
+   ```
+   This preserves the explore work for reference without cluttering the
+   active prototype directory.
+
+2. **Promote the winning idea**
+   Create an informal concept document at `design/concept.md` capturing:
+   - The core question the winning prototype answered
+   - Why it was chosen over alternatives
+   - Key findings from the explore report
+   - Estimated production effort
+
+   This is NOT a formal GDD — it is a lightweight concept document for the
+   Hybrid workflow's Discovery phase.
+
+3. **Enter Hybrid Discovery**
+   The Hybrid workflow starts with its Discovery phase. If the winning
+   prototype already answered the core mechanic question, you can:
+   - Skip to `/hybrid-prototype [winning-idea]` to build a playable
+     vertical slice
+   - Or go directly to mapping systems with `/map-systems`
+   - Or begin writing a GDD with `/design-system`
+
+4. **Reference explore findings**
+   Include links to the archived explore reports in any GDD or decision
+   document. The explore `REPORT.md` findings become the "Prior Art" that
+   informs the GDD's rules and tuning knobs.
+
+### Artifact Map
+
+| Artifact | Action | Destination |
+|----------|--------|-------------|
+| `prototypes/explore/[idea]/REPORT.md` | Archive | `prototypes/archive/explore/[date]/[idea]/REPORT.md` |
+| `prototypes/explore/[idea]/code/` | Archive (never reuse) | `prototypes/archive/explore/[date]/[idea]/code/` |
+| Winning idea design insight | Promote | `design/concept.md` |
+| Balance/config data | Evaluate | Promote if proven, rewrite if uncertain |
+| Placeholder assets | Discard | Replace with new assets in `assets/` |
+
+---
+
+## Path B: Explore → Full OCGS
+
+**Trigger**: `/gate-check workflow-selection` returns Full OCGS recommendation
+and user confirms.
+
+**Starting artifacts**: One or more reports in `prototypes/explore/*/REPORT.md`
+with PROMISING verdicts.
+
+### Steps
+
+1. **Archive exploration prototypes** (same as Path A)
+   ```
+   prototypes/explore/  →  prototypes/archive/explore/[date]/
+   ```
+
+2. **Formalize the concept**
+   Run `/brainstorm [winning-idea]` to produce a formal game concept document
+   at `design/gdd/game-concept.md` with full MDA analysis, pillars, core loop,
+   and player journey.
+
+   The explore findings feed directly into the brainstorm — the core question
+   has already been answered, so the concept document can be more specific
+   than a typical brainstorm output.
+
+3. **Set up the engine**
+   Run `/setup-engine [engine]` to pin the engine version, generate technical
+   preferences, and populate engine reference docs.
+
+4. **Design the systems**
+   Run `/map-systems` to enumerate all systems, then `/design-system` per
+   system to write formal 8-section GDDs. The explore prototype's findings
+   directly inform each GDD's rules, formulas, and tuning knobs.
+
+5. **Reference explore findings**
+   Embed links to the archived explore `REPORT.md` files in the GDDs. For
+   example, in the combat system GDD's "Tuning Knobs" section: "Prototype
+   testing showed that damage values above 50 felt too punishing — validated
+   range: 10-40."
+
+### Artifact Map
+
+| Artifact | Action | Destination |
+|----------|--------|-------------|
+| `prototypes/explore/[idea]/REPORT.md` | Archive, cross-reference | `prototypes/archive/explore/[date]/[idea]/REPORT.md` |
+| `prototypes/explore/[idea]/code/` | Archive (never reuse) | `prototypes/archive/explore/[date]/[idea]/code/` |
+| Winning idea | Formalize | `design/gdd/game-concept.md` (via `/brainstorm`) |
+| Prototype findings | Embed in GDDs | `design/gdd/[system].md` (Tuning Knobs, Edge Cases sections) |
+| Engine (none yet) | Set up | Via `/setup-engine` |
+
+---
+
+## Path C: Hybrid Discovery → Full OCGS
+
+**Trigger**: Any of the conditions in [When to Switch to Full OCGS](hybrid-workflow.md#when-to-switch-to-full-ocgs)
+become true: team grows beyond 5, timeline exceeds 6 months, publisher
+requirements, or need for live ops / analytics / multiplayer.
+
+**Starting artifacts**: Hybrid Discovery artifacts — informal concept doc,
+prototypes in `prototypes/`, lightweight specs in `design/quick-specs/`.
+
+### Steps
+
+1. **Archive Discovery prototypes**
+   ```
+   prototypes/[discovery-proto]/  →  prototypes/archive/discovery/[date]/
+   ```
+
+2. **Promote surviving designs to formal GDDs**
+   For each system that was prototyped and validated:
+   - Run `/design-system retrofit design/gdd/[system].md` to add the
+     required 8 sections to any informal spec or bullet-point doc
+   - Or run `/design-system [system]` from scratch if no document exists
+   - Embed prototype findings (especially tuning knobs and edge cases)
+
+3. **Write ADRs for proven systems**
+   Run `/architecture-decision` for each architectural choice that was
+   implicitly made during prototyping:
+   - Scene/state management approach
+   - Data flow between systems
+   - Save/load strategy
+   - Input handling architecture
+
+4. **Recruit additional agents**
+   Expand from the 4-role Hybrid roster to the full agent hierarchy.
+   See [Slimmed Agent Hierarchy](hybrid-workflow.md#slimmed-agent-hierarchy-49--10)
+   for which roles to add first.
+
+5. **Switch to `src/` with full coding standards**
+   All new code goes into `src/` with doc comments, dependency injection,
+   unit tests, and no hardcoded values. Do not move prototype code into
+   `src/` — rewrite from scratch.
+
+6. **Enable all quality gates**
+   - `/test-setup` to scaffold the test framework
+   - `/qa-plan` to generate QA plans
+   - `/gate-check` at every phase transition
+   - Enable pre-commit hooks for validation
+
+### Artifact Map
+
+| Artifact | Action | Destination |
+|----------|--------|-------------|
+| `prototypes/[proto]/` | Archive | `prototypes/archive/discovery/[date]/` |
+| `design/concept.md` (informal) | Promote | `design/gdd/game-concept.md` (formalize) |
+| `design/quick-specs/*.md` | Retrofit | `design/gdd/[system].md` (via `/design-system retrofit`) |
+| Prototype code | Archive (never reuse) | `prototypes/archive/discovery/[date]/` |
+| Implicit architecture decisions | Document | `docs/architecture/adr-[*].md` (via `/architecture-decision`) |
+
+---
+
+## Path D: Full OCGS Prototype → Production
+
+**Trigger**: A `/prototype` within the Full OCGS Phase 4 (Pre-Production)
+returns a PROCEED verdict and the creative director approves.
+
+**Starting artifacts**: `prototypes/[mechanic-name]/` with a `REPORT.md`
+and throwaway code.
+
+### Steps
+
+1. **Archive the prototype**
+   ```
+   prototypes/[mechanic-name]/  →  prototypes/archive/[date]-[mechanic-name]/
+   ```
+
+2. **Update the GDD with prototype findings**
+   Open the relevant system GDD at `design/gdd/[system].md` and add:
+   - Updated tuning knobs and safe ranges based on prototype data
+   - Edge cases discovered during prototyping
+   - Acceptance criteria that were validated
+   - Any formula adjustments found necessary
+
+3. **Create or update ADRs**
+   If the prototype revealed architectural requirements:
+   - Run `/architecture-decision` to record the decision
+   - Or update an existing ADR if the decision refines a previous one
+
+4. **Create stories from prototype insights**
+   Run `/create-stories [epic-slug]` with the prototype findings embedded
+   in the story acceptance criteria. The prototype report's "If Proceeding"
+   section is the direct input for implementation requirements.
+
+5. **Implement from scratch in `src/`**
+   The production implementation is written in `src/` with full coding
+   standards. The prototype code is reference only — do not copy, refactor,
+   or import from it.
+
+### Artifact Map
+
+| Artifact | Action | Destination |
+|----------|--------|-------------|
+| `prototypes/[mechanic]/REPORT.md` | Archive, cross-reference | `prototypes/archive/[date]-[mechanic]/REPORT.md` |
+| `prototypes/[mechanic]/code/` | Archive (never reuse) | `prototypes/archive/[date]-[mechanic]/code/` |
+| Updated tuning ranges | Promote to GDD | `design/gdd/[system].md` (Tuning Knobs section) |
+| Discovered edge cases | Promote to GDD | `design/gdd/[system].md` (Edge Cases section) |
+| Architectural requirements | Promote to ADR | `docs/architecture/adr-[*].md` |
+| Implementation scope | Promote to stories | `production/epics/[slug]/story-[*].md` |
+
+---
+
+## Quick Reference
+
+| What | Promote? | Rule |
+|------|----------|------|
+| Source code | Never | Rewrite from scratch |
+| Scenes / levels | Never | Rebuild from scratch |
+| Placeholder assets | Never | Replace with production assets |
+| Design insights | Always | Merge into GDDs or concept docs |
+| Tuning data | Evaluate | Promote if empirically validated; retest if uncertain |
+| Edge cases | Always | Document in GDD Edge Cases section |
+| Acceptance criteria | Always | Include in story files |
+| Architecture patterns | Evaluate | Document via ADR if proven; revisit if uncertain |
+| Config files | Never | Recreate with production structure |
+| Research notes | Always | Archive as-is for reference |
+
+---
+
+## See Also
+
+- [`docs/hybrid-workflow.md`](hybrid-workflow.md) — Hybrid Discovery-Production workflow
+- [`docs/WORKFLOW-GUIDE.md`](WORKFLOW-GUIDE.md) — Full OCGS 7-phase workflow
+- `.opencode/skills/explore/SKILL.md` — Pre-workflow prototyping skill
+- `.opencode/skills/gate-check/SKILL.md` — Workflow Selection gate


### PR DESCRIPTION
## Summary
Creates \docs/workflow-transitions.md\ covering all 4 transition paths with clear promotion rules per artifact type.

## Changes
- Path A: Explore -> Hybrid (informal concept, archive explore)
- Path B: Explore -> Full OCGS (formal GDDs, \/setup-engine\)
- Path C: Hybrid Discovery -> Full OCGS (retrofit GDDs, write ADRs)
- Path D: Full OCGS Prototype -> Production (promote findings to GDDs)
- Quick reference table: what promotes vs. what gets rewritten
- Core principle: code never promotes, design insights always promote
- Cross-referenced from \hybrid-workflow.md\ and \WORKFLOW-GUIDE.md\

Closes #44