### PR TITLE
feat: integrate unity-mcp (CoplayDev) into OCGS framework

### DIFF
--- a/.opencode/modules/core/skills/setup-engine/SKILL.md
+++ b/.opencode/modules/core/skills/setup-engine/SKILL.md
@@ -440,6 +440,61 @@ Optionally set `GODOT_PATH` if the Godot binary is not in PATH:
 }
 ```
 
+### 7.4. Configure unity-mcp (Optional — Unity Only)
+
+> **What it is:** A bridge between AI agents and Unity Editor via MCP, exposing ~50+ tools for scene, script, and asset management. Maintained by CoplayDev, MIT licensed. See [github.com/CoplayDev/unity-mcp](https://github.com/CoplayDev/unity-mcp).
+
+#### Prerequisites (must be installed first)
+
+- **Unity 2021.3 LTS or newer** — [Download Unity](https://unity.com/download)
+- **Python 3.10+** with `uv` — install `uv` via `pip install uv` (or `winget install astral-sh.uv` on Windows)
+- **MCP for Unity package** installed in your Unity project (see below)
+
+#### Install steps
+
+In your Unity project, open **Window → Package Manager**, click the **`+`** button, choose **Add package from git URL...**, and paste:
+
+```
+https://github.com/CoplayDev/unity-mcp.git?path=/MCPForUnity#main
+```
+
+> Use `#beta` instead of `#main` for the latest beta features. `#main` is recommended for stability and currently tracks the v9.7.0 release.
+
+After the package imports, MCP for Unity opens a **setup wizard** automatically:
+
+1. Confirm Python and `uv` are installed — the wizard guides you through both if missing.
+2. Click **Done**. Once dependencies are green, a list of detected MCP clients appears.
+3. Pick the clients you want to configure and click **Configure Selected**.
+
+> **Note:** The wizard's per-client list (Claude Desktop, Cursor, Claude Code, VS Code, Windsurf, Cline, etc.) does not explicitly mention OpenCode. The wizard MAY auto-configure OpenCode's `opencode.json` (verify by checking the file after); if it does not, use the manual config below.
+
+#### Manual opencode.json config (reliable fallback)
+
+Add this block to the `mcp` object in your project's `opencode.json`:
+
+```json
+"unity": {
+  "type": "local",
+  "url": "http://localhost:8080/mcp",
+  "enabled": false
+}
+```
+
+`enabled: false` is the default. Flip to `true` once Unity Editor is running and you want OCGS agents to use unity-mcp tools.
+
+> ⚠ **Unity Editor must be running** before OCGS agents can use unity-mcp tools. If the Editor is closed, MCP calls will fail with a connection error. Open your project in Unity, then continue.
+
+#### Verify
+
+In a session where `enabled: true`, call any unity-mcp tool (e.g. `list_scenes`) via OCGS. Expect a list of scenes from your open Unity project.
+
+#### Troubleshooting
+
+- **Bridge not connecting** — Open **Window → MCP for Unity** and check the status panel. Restart Unity if needed.
+- **Server not starting** — Verify `uv --version` works in your terminal. Check the MCP for Unity log for errors.
+- **Client not connecting** — Confirm the HTTP server is running on `localhost:8080` and the URL in your client config matches.
+- **Port 8080 conflict** — Open Unity's MCP for Unity window and change the port; update the `url` in `opencode.json` to match.
+
 ---
 
 ## 8. Update CLAUDE.md Import

--- a/.opencode/modules/engine-unity/agents/unity-addressables-specialist.md
+++ b/.opencode/modules/engine-unity/agents/unity-addressables-specialist.md
@@ -163,3 +163,7 @@ handle.Completed += OnAssetLoaded;
 - Work with **devops-engineer** for CDN and content delivery pipeline
 - Work with **level-designer** for scene streaming boundaries
 - Work with **unity-ui-specialist** for UI asset loading patterns
+
+## MCP Integration
+
+- Use the unity-mcp server (`manage_asset` for Addressable groups and assets, `manage_package` for Addressables package management, `read_console`) to verify Addressables groups build and watch for build errors in the Unity console. Requires Unity Editor running and `opencode.json` `mcp.unity.enabled: true`.

--- a/.opencode/modules/engine-unity/agents/unity-dots-specialist.md
+++ b/.opencode/modules/engine-unity/agents/unity-dots-specialist.md
@@ -146,3 +146,7 @@ Before writing any code:
 - Work with **performance-analyst** for profiling DOTS performance
 - Work with **engine-programmer** for low-level optimization
 - Work with **unity-shader-specialist** for Entities Graphics rendering
+
+## MCP Integration
+
+- Use the unity-mcp server (`create_script`, `script_apply_edits`, `validate_script`, `manage_scene` with action `load`) to verify ECS code compiles and runs in-editor. Requires Unity Editor running and `opencode.json` `mcp.unity.enabled: true`.

--- a/.opencode/modules/engine-unity/agents/unity-shader-specialist.md
+++ b/.opencode/modules/engine-unity/agents/unity-shader-specialist.md
@@ -176,3 +176,7 @@ Before writing any code:
 - Work with **performance-analyst** for GPU performance profiling
 - Work with **unity-dots-specialist** for Entities Graphics rendering
 - Work with **unity-ui-specialist** for UI shader effects
+
+## MCP Integration
+
+- Use the unity-mcp server (`manage_material`, `manage_asset` for shader files, `read_console`) to apply material/shader changes and watch for shader compile errors in the Unity console. Requires Unity Editor running and `opencode.json` `mcp.unity.enabled: true`.

--- a/.opencode/modules/engine-unity/agents/unity-specialist.md
+++ b/.opencode/modules/engine-unity/agents/unity-specialist.md
@@ -182,3 +182,7 @@ Always involve this agent when:
 - Implementing UI with UI Toolkit or UGUI
 - Building for any platform
 - Optimizing with Unity-specific tools
+
+## MCP Integration
+
+- Use the unity-mcp server (`read_console`, `manage_scene` with actions `get_active` / `get_hierarchy`, resource `mcpforunity://editor/state`) to audit project state and verify in-editor behavior during development sessions. Requires Unity Editor running and `opencode.json` `mcp.unity.enabled: true`.

--- a/.opencode/modules/engine-unity/agents/unity-ui-specialist.md
+++ b/.opencode/modules/engine-unity/agents/unity-ui-specialist.md
@@ -215,3 +215,7 @@ Before writing any code:
 - Work with **unity-addressables-specialist** for UI asset loading
 - Work with **localization-lead** for text fitting and localization
 - Work with **accessibility-specialist** for compliance
+
+## MCP Integration
+
+- Use the unity-mcp server (`manage_ui` for UI Toolkit workflows, `manage_scene` for Canvas/uGUI hierarchies, `create_script` for UI scripts) to scaffold UI hierarchies and run scenes to verify UI behavior. Requires Unity Editor running and `opencode.json` `mcp.unity.enabled: true`.

--- a/.opencode/modules/engine-unity/modulefile.yaml
+++ b/.opencode/modules/engine-unity/modulefile.yaml
@@ -1,6 +1,6 @@
 name: engine-unity
-version: "0.6.0"
-description: "Unity engine specialists — DOTS/ECS, shaders, Addressables, UI."
+version: "0.7.0"
+description: "Unity engine specialists — DOTS/ECS, shaders, Addressables, UI. Includes unity-mcp integration for interactive AI-assisted dev."
 depends: [core]
 provides:
   agents: [unity-specialist, unity-dots-specialist, unity-shader-specialist,

--- a/.opencode/skills/setup-engine/SKILL.md
+++ b/.opencode/skills/setup-engine/SKILL.md
@@ -682,7 +682,62 @@ Optionally set `GODOT_PATH` if the Godot binary is not in PATH:
 }
 ```
 
-### 7.4. Build & Run Setup (SFML 3 / Raylib — No MCP Available)
+### 7.4. Configure unity-mcp (Optional — Unity Only)
+
+> **What it is:** A bridge between AI agents and Unity Editor via MCP, exposing ~50+ tools for scene, script, and asset management. Maintained by CoplayDev, MIT licensed. See [github.com/CoplayDev/unity-mcp](https://github.com/CoplayDev/unity-mcp).
+
+#### Prerequisites (must be installed first)
+
+- **Unity 2021.3 LTS or newer** — [Download Unity](https://unity.com/download)
+- **Python 3.10+** with `uv` — install `uv` via `pip install uv` (or `winget install astral-sh.uv` on Windows)
+- **MCP for Unity package** installed in your Unity project (see below)
+
+#### Install steps
+
+In your Unity project, open **Window → Package Manager**, click the **`+`** button, choose **Add package from git URL...**, and paste:
+
+```
+https://github.com/CoplayDev/unity-mcp.git?path=/MCPForUnity#main
+```
+
+> Use `#beta` instead of `#main` for the latest beta features. `#main` is recommended for stability and currently tracks the v9.7.0 release.
+
+After the package imports, MCP for Unity opens a **setup wizard** automatically:
+
+1. Confirm Python and `uv` are installed — the wizard guides you through both if missing.
+2. Click **Done**. Once dependencies are green, a list of detected MCP clients appears.
+3. Pick the clients you want to configure and click **Configure Selected**.
+
+> **Note:** The wizard's per-client list (Claude Desktop, Cursor, Claude Code, VS Code, Windsurf, Cline, etc.) does not explicitly mention OpenCode. The wizard MAY auto-configure OpenCode's `opencode.json` (verify by checking the file after); if it does not, use the manual config below.
+
+#### Manual opencode.json config (reliable fallback)
+
+Add this block to the `mcp` object in your project's `opencode.json`:
+
+```json
+"unity": {
+  "type": "local",
+  "url": "http://localhost:8080/mcp",
+  "enabled": false
+}
+```
+
+`enabled: false` is the default. Flip to `true` once Unity Editor is running and you want OCGS agents to use unity-mcp tools.
+
+> ⚠ **Unity Editor must be running** before OCGS agents can use unity-mcp tools. If the Editor is closed, MCP calls will fail with a connection error. Open your project in Unity, then continue.
+
+#### Verify
+
+In a session where `enabled: true`, call any unity-mcp tool (e.g. `list_scenes`) via OCGS. Expect a list of scenes from your open Unity project.
+
+#### Troubleshooting
+
+- **Bridge not connecting** — Open **Window → MCP for Unity** and check the status panel. Restart Unity if needed.
+- **Server not starting** — Verify `uv --version` works in your terminal. Check the MCP for Unity log for errors.
+- **Client not connecting** — Confirm the HTTP server is running on `localhost:8080` and the URL in your client config matches.
+- **Port 8080 conflict** — Open Unity's MCP for Unity window and change the port; update the `url` in `opencode.json` to match.
+
+### 7.5. Build & Run Setup (SFML 3 / Raylib — No MCP Available)
 
 SFML 3 and Raylib do not have MCP servers. Instead, configure a build-and-run workflow:
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -78,6 +78,33 @@ Configure via `opencode.json` MCP settings (see `setup-engine` skill section 7.3
 - `.opencode/docs/quick-start.md` — setup step added, steps renumbered
 - `.opencode/docs/skills-reference.md` — automated-smoke-test entry added
 
+## v0.4.0 — Unity MCP Integration
+
+**New MCP server:** unity-mcp (CoplayDev), for interactive AI-assisted dev with Unity Editor.
+
+### What changed
+- **New MCP integration**: `unity` — Adds optional support for the [CoplayDev unity-mcp](https://github.com/CoplayDev/unity-mcp) server, giving OCGS agents in Unity projects access to ~50+ tools for scene, script, and asset management. Requires Unity Editor running. Configure via `setup-engine` §7.4.
+- **setup-engine skill**: Added section 7.4 covering unity-mcp prerequisites (Unity 2021.3+, Python 3.10+, `uv`), install steps, and the Editor-running constraint.
+- **Module version**: `engine-unity` bumped from 0.6.0 → 0.7.0; description updated to mention the unity-mcp integration.
+- **Agent files**: 5 unity specialists (`unity-specialist`, `unity-dots-specialist`, `unity-shader-specialist`, `unity-addressables-specialist`, `unity-ui-specialist`) updated with new `## MCP Integration` sections referencing domain-specific unity-mcp tools.
+- **opencode.json**: New `mcp.unity` block (HTTP, `http://localhost:8080/mcp`, disabled by default) — mirrors the `mcp.godot` pattern.
+
+### New dependency (optional)
+The unity-mcp integration requires the CoplayDev unity-mcp package installed in your Unity project (via Unity Package Manager git URL). The integration itself is opt-in: users set `mcp.unity.enabled: true` in `opencode.json` after installing.
+
+### Safe to overwrite
+- `.opencode/modules/engine-unity/modulefile.yaml`
+
+### Merge carefully
+- `opencode.json` — new `mcp.unity` block; if you've customized this file, merge the new block into your existing `mcp` object
+- `.opencode/skills/setup-engine/SKILL.md` — has new section 7.4 (and §7.4 SFML3/Raylib renumbered to §7.5 in the root monolith; core copy has just §7.4 with no §7.5 because SFML3/Raylib are optional modules)
+- `.opencode/modules/core/skills/setup-engine/SKILL.md` — has new section 7.4 (mirror of the root change, no renumbering)
+- `.opencode/modules/engine-unity/agents/unity-specialist.md` — new `## MCP Integration` section
+- `.opencode/modules/engine-unity/agents/unity-dots-specialist.md` — new `## MCP Integration` section
+- `.opencode/modules/engine-unity/agents/unity-shader-specialist.md` — new `## MCP Integration` section
+- `.opencode/modules/engine-unity/agents/unity-addressables-specialist.md` — new `## MCP Integration` section
+- `.opencode/modules/engine-unity/agents/unity-ui-specialist.md` — new `## MCP Integration` section
+
 ### Strategy C — Manual file copy
 
 Best when: you didn't use git to set up the template (just downloaded a zip).

--- a/opencode.json
+++ b/opencode.json
@@ -25,6 +25,11 @@
         "GODOT_PATH": "{env:GODOT_PATH}",
         "DEBUG": "{env:DEBUG}"
       }
+    },
+    "unity": {
+      "type": "local",
+      "url": "http://localhost:8080/mcp",
+      "enabled": false
     }
   },
   "permission": {


### PR DESCRIPTION
## Summary

Adds the [CoplayDev unity-mcp](https://github.com/CoplayDev/unity-mcp) server as a third MCP integration in OCGS, alongside the existing `aseprite` and `godot` MCPs. Mirrors the established patterns throughout.

- **MCP config**: New `mcp.unity` block in `opencode.json` (HTTP, `localhost:8080`, disabled by default) — same opt-in shape as `mcp.godot`
- **Skill docs**: New §7.4 in `setup-engine/SKILL.md` (root + core module copies, byte-identical) covering prerequisites, install, Editor-running constraint, manual config fallback, and troubleshooting
- **Agent references**: All 5 unity specialists (`unity-specialist` + 4 sub-specialists) gain a `## MCP Integration` section with domain-specific tool hints
- **Module version**: `engine-unity` bumped 0.6.0 → 0.7.0
- **Changelog**: New `v0.4.0 — Unity MCP Integration` section in `UPGRADING.md`

## Transport choice

HTTP (`http://localhost:8080/mcp`), the upstream default. Unity MCP runs as a package inside Unity Editor, not as a standalone CLI, so it differs from the godot/aseprite `command: [...]` shape — this is a deliberate, documented divergence.

## Test Plan

- [x] `node tests/agents/validate.mjs` → 182/182 PASS (51 agents, 77 skills, 53 commands, 1 cross-reference)
- [x] `node .opencode/plugins/tests/test-*.mjs` → 11/11 files, 129/129 scenarios PASS
- [x] `opencode.json` valid JSON
- [x] §7.4 unity-mcp content byte-identical between `.opencode/skills/setup-engine/SKILL.md` and `.opencode/modules/core/skills/setup-engine/SKILL.md` (modular framework invariant preserved)
- [x] All 5 unity specialists have `## MCP Integration` section with identical closing clause
- [x] Pre-existing §7.4 (Build & Run Setup for SFML3/Raylib) renumbered to §7.5 in root monolith; no renumbering needed in core copy (SFML3/Raylib are optional modules absent from core)

## Non-blocking follow-ups

Two spec-inherited tool-name nits surfaced during final review — fixable in a follow-up spec amendment, do not block merge:

- `manage_package` (singular) → `manage_packages` (plural) in `unity-addressables-specialist.md` and `setup-engine/SKILL.md` §7.4 references
- `list_scenes` in §7.4 "Verify" example isn't a documented tool; closest is `manage_scene(action="get_active")`

## Notes

- Spec and plan files in `framework/docs/superpowers/` were created locally and intentionally NOT committed to this branch (treated as local-only working artifacts)
- Per the implementation plan, an automated smoke-test skill for Unity is out of scope (Unity in batchmode is finicky); integration is interactive-dev only
