### PR TITLE
chore: add superpowers paths to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,11 @@ opencode-config-verify.json
 production/session-logs/
 production/session-state/
 
+# Superpowers SDK design docs (not part of OCGS)
+.superpowers/
+docs/superpowers/
+framework/
+
 # Git worktrees
 .worktrees/
 


### PR DESCRIPTION
Prevents re-introducing superpowers SDK design docs that were purged from history.