### PR TITLE
docs: add Pi awareness across README and framework docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,11 @@ opencode-config-verify.json
 production/session-logs/
 production/session-state/
 
+# Superpowers SDK design docs (not part of OCGS)
+.superpowers/
+docs/superpowers/
+framework/
+
 # Git worktrees
 .worktrees/
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,12 +2,18 @@
 
 Thanks for your interest in OpenCode Game Studios!
 
+OpenCode Game Studios runs on both [OpenCode](https://opencode.ai) and [Pi](https://github.com/earendil-works/pi-coding-agent).
+
 ## Quick Start
 
+### OpenCode
 ```bash
-git clone https://github.com/striderZA/OpenCodeGameStudios.git
-cd OpenCodeGameStudios
 opencode
+```
+
+### Pi
+```bash
+pi
 ```
 
 ## How to Contribute

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <img src="assets/banner.png" alt="OpenCode Game Studios Banner" width="100%">
 </p>
 
-> ⚡ Evolved from [Claude Code Game Studios (CCGS)](https://github.com/Donchitos/Claude-Code-Game-Studios) — now a standalone framework with workflow selection, phase gates, pre-workflow prototyping, and hybrid discovery-to-production pipelines.
+> ⚡ Evolved from [Claude Code Game Studios (CCGS)](https://github.com/Donchitos/Claude-Code-Game-Studios) — now a standalone framework supporting both [OpenCode](https://opencode.ai) and [Pi](https://github.com/earendil-works/pi-coding-agent) coding agents.
 
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![Agents](https://img.shields.io/badge/agents-51-blueviolet)](.agents/agents/)
@@ -13,6 +13,7 @@
 [![Hooks](https://img.shields.io/badge/plugins-3-orange)](.opencode/plugins/)
 [![Tests](https://img.shields.io/badge/tests-183-success)](tests/)
 [![Built for OpenCode](https://img.shields.io/badge/built%20for-OpenCode-5f5f5f)](https://opencode.ai)
+[![Pi Compatible](https://img.shields.io/badge/Pi-compatible-4f46e5)](https://github.com/earendil-works/pi-coding-agent)
 
 ---
 
@@ -56,7 +57,7 @@ for the full game lifecycle:
   `/concept-brainstorm` to `/launch-checklist`
 
 This project evolved from [CCGS](https://github.com/Donchitos/Claude-Code-Game-Studios)
-and runs on [OpenCode](https://opencode.ai).
+and runs on [OpenCode](https://opencode.ai) and [Pi](https://github.com/earendil-works/pi-coding-agent).
 
 ---
 
@@ -68,24 +69,31 @@ and runs on [OpenCode](https://opencode.ai).
 
 ## 📊 Port Status
 
-| Component | CCGS (Claude Code) | OpenCode | Status |
-|-----------|-------------------|----------|--------|
-| 🤖 **Agents** | 49 agents (`.claude/agents/`) | 51 agents (`.agents/agents/`) | ✅ |
-| ⌨️ **Skills** | 72 skills (`.claude/skills/`) | 77 skills (`.agents/skills/`) | ✅ +5 |
-| ⌨️ **Commands** | — | 54 commands (`.agents/commands/`) | ✅ New |
-| 🔗 **Plugins** | 12 bash hooks (`.claude/hooks/`) | 3 TS plugins (`.opencode/plugins/`) | ✅ **183 tests** |
-| 📏 **Rules** | 11 rule files (`.claude/rules/`) | 11 rule files (`.agents/rules/`) | ✅ |
-| ⚙️ **Config** | `CLAUDE.md` + `.claude/settings.json` | `AGENTS.md` + `opencode.json` | ✅ |
+| Component | CCGS (Claude Code) | OpenCode | Pi | Status |
+|-----------|-------------------|----------|-----|--------|
+| 🤖 **Agents** | 49 agents (`.claude/agents/`) | 51 agents (`.agents/agents/`) | 51 agents (`.agents/agents/`) | ✅ |
+| ⌨️ **Skills** | 72 skills (`.claude/skills/`) | 77 skills (`.agents/skills/`) | 77 skills (`.agents/skills/`) | ✅ +5 |
+| ⌨️ **Commands** | — | 54 commands (`.agents/commands/`) | → prompt templates | ✅ New |
+| 🔗 **Plugins** | 12 bash hooks (`.claude/hooks/`) | 3 TS plugins (`.opencode/plugins/`) | 7 Pi extensions (`.pi/extensions/`) | ✅ **183 tests** |
+| 📏 **Rules** | 11 rule files (`.claude/rules/`) | 11 rule files (`.agents/rules/`) | 11 rule files (`.agents/rules/`) | ✅ |
+| ⚙️ **Config** | `CLAUDE.md` + `.claude/settings.json` | `AGENTS.md` + `opencode.json` | `AGENTS.md` + `pi.json` | ✅ |
 
 ---
 
 ## 🚀 Quick Start
 
+### OpenCode
 ```bash
 opencode
 ```
-
 Type `/` to browse all 77 skills and 54 commands, or `/start` for onboarding.
+
+### Pi
+```bash
+pi
+```
+All OCGS skills, commands, and agents load automatically through Pi extensions.
+See [docs/pi-compatibility.md](docs/pi-compatibility.md) for setup details.
 
 ### 🎮 Demo Game
 
@@ -150,8 +158,7 @@ all game development sessions:
 | [**dynamic-context-purging**](https://github.com/Opencode-DCP/opencode-dynamic-context-pruning)| Dynamic context pruning — automatically manages context window size, indexes content for search, and prevents context overflow during long sessions |
 | [**Superpowers**](https://github.com/obra/superpowers) | Enhanced skill library — provides structured workflows for brainstorming, test-driven development, writing plans, code review, and parallel agent dispatch |
 
-Add them to your `opencode.json`:
-
+**OpenCode:** Add to your `opencode.json`:
 ```json
 {
   "plugin": [
@@ -161,18 +168,21 @@ Add them to your `opencode.json`:
 }
 ```
 
+**Pi:** OCGS Pi extensions are bundled in `.pi/extensions/` and auto-discovered
+on startup. See [docs/pi-extensions.md](docs/pi-extensions.md) for details.
+
 ---
 
 ## 🗺️ Key Mappings
 
-| CCGS (Claude Code) | OpenCode |
-|--------------------|----------|
-| `.claude/skills/*.md` → | `.agents/skills/*.md` |
-| `.claude/agents/*.md` → | `.agents/agents/*.md` |
-| `.claude/hooks/*.sh` → | `.opencode/plugins/ccgs-hooks.ts` |
-| `.claude/rules/*.md` → | `.agents/rules/*.md` |
-| `CLAUDE.md` → | `AGENTS.md` |
-| `.claude/settings.json` → | `opencode.json` |
+| CCGS (Claude Code) | OpenCode | Pi |
+|--------------------|----------|-----|
+| `.claude/skills/*.md` → | `.agents/skills/*.md` | `.agents/skills/*.md` |
+| `.claude/agents/*.md` → | `.agents/agents/*.md` | `.agents/agents/*.md` |
+| `.claude/hooks/*.sh` → | `.opencode/plugins/ccgs-hooks.ts` | `.pi/extensions/` |
+| `.claude/rules/*.md` → | `.agents/rules/*.md` | `.agents/rules/*.md` |
+| `CLAUDE.md` → | `AGENTS.md` | `AGENTS.md` |
+| `.claude/settings.json` → | `opencode.json` | `pi.json` |
 
 ---
 
@@ -255,6 +265,7 @@ node utils/assign-models.js --config my-models.json
 /
 ├── AGENTS.md                  📋 Project configuration
 ├── opencode.json              ⚙️ OpenCode config (permissions, plugins)
+├── pi.json                    ⚙️ Pi config (MCP, settings)
 ├── .agents/                   📦 Canonical content (harness-agnostic)
 │   ├── agents/                🤖 51 agent definitions
 │   ├── skills/                🛠️ 77 skill workflows
@@ -277,10 +288,16 @@ node utils/assign-models.js --config my-models.json
 │       ├── installed.json     Module manifest
 │       └── ...                21 module sources
 ├── design/                    🎨 Game design documents
+├── .pi/                        ⚙️ Pi-specific extensions & settings
+│   └── extensions/            🧩 Pi extensions (ocgs-core, delegation, question, etc.)
 ├── docs/
 │   ├── CONTRIBUTING.md        📖 Framework contribution guide
 │   ├── authoring-agents.md    🤖 Agent authoring guide
 │   ├── authoring-skills.md    🛠️ Skill authoring guide
+│   ├── pi-compatibility.md    🔧 Pi setup guide
+│   ├── pi-extensions.md       🧩 Pi extension reference
+│   ├── pi-workflow.md         🔄 Pi workflow differences
+│   ├── framework/             🏛️ OCGS framework reference docs & templates
 │   ├── architecture/          🏗️ ADRs
 │   └── engine-reference/      📚 Engine API reference
 ├── tests/

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -4,6 +4,9 @@ This guide covers how to add, modify, and maintain the OCGS framework —
 agents, skills, commands, rules, and plugins. If you're building a game
 (rather than the framework), see `README.md` instead.
 
+The framework supports both [OpenCode](https://opencode.ai) and [Pi](https://github.com/earendil-works/pi-coding-agent) coding agents.
+See `docs/pi-compatibility.md` for Pi-specific setup.
+
 ## Table of Contents
 
 1. [Framework Architecture](#framework-architecture)

--- a/docs/framework/quick-start.md
+++ b/docs/framework/quick-start.md
@@ -2,7 +2,12 @@
 
 ## What Is This?
 
-This is a complete OpenCode agent architecture for game development. It
+# Game Studio Agent Architecture -- Quick Start Guide
+
+## What Is This?
+
+This is a complete agent architecture for game development, supporting both
+[OpenCode](https://opencode.ai) and [Pi](https://github.com/earendil-works/pi-coding-agent). It
 organizes 48 specialized AI agents into a studio hierarchy that mirrors
 real game development teams, with defined responsibilities, delegation
 rules, and coordination protocols. It includes engine-specialist agents
@@ -232,7 +237,7 @@ If you already know what you need, jump directly to the relevant path:
     # In Unity: Window → Package Manager → + → Add package from git URL
     # Paste: https://github.com/CoplayDev/unity-mcp.git?path=/MCPForUnity#main
     ```
-    Then add the `mcp.unity` block to your `opencode.json` and set
+    Then add the `mcp.unity` block to your MCP config (`opencode.json` for OpenCode, `pi.json` for Pi) and set
     `enabled: true` once Unity Editor is running. See `/setup-engine` §7.4
     for full details.
 5. **Validate the concept** — Run `/design-review design/gdd/game-concept.md`
@@ -285,6 +290,24 @@ If you have design docs, prototypes, or code already:
 The framework is partitioned into **theme modules**. Only install what you need:
 
 ```bash
+## Installation
+
+### OpenCode
+```bash
+opencode
+```
+Type `/` to browse all skills and commands, or `/start` for onboarding.
+
+### Pi
+```bash
+pi
+```
+All OCGS skills, commands, and agents load automatically through Pi extensions.
+See `docs/pi-compatibility.md` for full setup.
+
+### Install Modules
+
+```bash
 node .opencode/modules/install.mjs add core          # Required: directors, /start, /help
 node .opencode/modules/install.mjs add engine-godot  # Engine specialists (or engine-unity/engine-unreal)
 node .opencode/modules/install.mjs add art           # Aseprite MCP, art bible, asset specs
@@ -299,8 +322,9 @@ Available modules: art, design, architecture, stories, programming, ui, audio, n
 
 ```
 AGENTS.md                          -- Master config (read this first)
-.opencode/
-  (opencode.json at root)          -- OpenCode settings and plugin configuration
+.opencode/  (opencode.json at root) -- OpenCode settings & plugin config
+.pi/           (pi.json at root)       -- Pi MCP & settings
+  extensions/                         -- 7 Pi extensions (auto-discovered)
   agents/                          -- Agent definitions (YAML frontmatter)
   skills/                          -- Skill definitions (YAML frontmatter)
   plugins/                         -- TypeScript hooks plugin (ccgs-hooks.ts)

--- a/docs/framework/setup-requirements.md
+++ b/docs/framework/setup-requirements.md
@@ -11,7 +11,8 @@ you'll lose validation features.
 | Tool | Purpose | Install |
 | ---- | ---- | ---- |
 | **Git** | Version control, branch management | [git-scm.com](https://git-scm.com/) |
-| **OpenCode** | AI agent CLI | `npm install -g opencode` |
+| **OpenCode** | AI agent CLI (via OpenCode) | `npm install -g opencode` |
+| **Pi** | AI agent CLI (via Pi) | `npm install -g @earendil-works/pi-coding-agent` |
 | **Node.js 18+** | Module CLI + hooks | Runtime for `install.mjs` and the CCGS TypeScript hooks plugin | [nodejs.org](https://nodejs.org/) |
 
 ## Recommended


### PR DESCRIPTION
Adds Pi as a supported harness across all key documentation.

- README.md: Pi badge, port status column, quick start, key mappings, directory tree, plugin config
- CONTRIBUTING.md: Pi mentioned as supported CLI
- docs/CONTRIBUTING.md: Pi added to framework intro
- docs/framework/quick-start.md: Pi install, config, and setup steps
- docs/framework/setup-requirements.md: Pi added to required tools table