### PR TITLE
fix: resolve Windows symlink compatibility in framework validators (#77)

### DIFF
--- a/tests/agents/validate-gdscript.mjs
+++ b/tests/agents/validate-gdscript.mjs
@@ -68,7 +68,7 @@ function validateSnippet(code, file, blockIndex) {
 }
 
 function validateAgentFiles() {
-  const agentsDir = join(ROOT, '.opencode', 'agents');
+  const agentsDir = join(ROOT, '.agents', 'agents');
   if (!existsSync(agentsDir)) {
     console.log('No agents directory found');
     process.exit(0);

--- a/tests/modules/validate-modules.mjs
+++ b/tests/modules/validate-modules.mjs
@@ -10,10 +10,10 @@ let passed = 0;
 let failed = 0;
 
 const PATH_MAP = {
-  agents:   (name) => join(ROOT, ".opencode", "agents", `${name}.md`),
-  skills:   (name) => join(ROOT, ".opencode", "skills", name, "SKILL.md"),
-  commands: (name) => join(ROOT, ".opencode", "commands", `${name}.md`),
-  rules:    (name) => join(ROOT, ".opencode", "rules", `${name}.md`),
+  agents: (name) => join(ROOT, ".agents", "agents", `${name}.md`),
+  skills: (name) => join(ROOT, ".agents", "skills", name, "SKILL.md"),
+  commands: (name) => join(ROOT, ".agents", "commands", `${name}.md`),
+  rules: (name) => join(ROOT, ".agents", "rules", `${name}.md`),
 };
 
 function parseModulefile(filePath) {

--- a/tests/workflow/gates.mjs
+++ b/tests/workflow/gates.mjs
@@ -7,7 +7,7 @@ import { fileURLToPath } from 'url';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(__dirname, '..', '..');
 
-const SKILLS_DIR = join(ROOT, '.opencode', 'skills');
+const SKILLS_DIR = join(ROOT, '.agents', 'skills');
 
 function getSkillContent(name) {
   const p = join(SKILLS_DIR, name, 'SKILL.md');
@@ -69,8 +69,8 @@ if (gate) {
       'production/session-logs/',
       'prototypes/explore/',
       'design/difficulty-curve.md',
-      '.opencode/docs/technical-preferences.md',
-      '.opencode/docs/director-gates.md',
+      'docs/framework/technical-preferences.md',
+      'docs/framework/director-gates.md',
       '.github/workflows/tests.yml',
       'docs/consistency-failures.md',
     ]);
@@ -179,7 +179,7 @@ if (gate) {
     const hybrid = readFileSync(hybridDoc, 'utf-8');
     const refs = [...hybrid.matchAll(/`\/([a-z][\w-]+)`/g)].map(m => m[1]);
     const unique = [...new Set(refs)];
-    const commandsDir = join(ROOT, '.opencode', 'commands');
+    const commandsDir = join(ROOT, '.agents', 'commands');
     const commandNames = existsSync(commandsDir)
       ? new Set(readdirSync(commandsDir).filter(f => f.endsWith('.md') && f !== 'README.md').map(f => f.replace('.md', '')))
       : new Set();
@@ -210,7 +210,7 @@ if (gate) {
       const content = readFileSync(doc, 'utf-8');
       const refs = [...content.matchAll(/`\/([a-z][\w-]+)`/g)].map(m => m[1]);
       const unique = [...new Set(refs)];
-      const commandsDir = join(ROOT, '.opencode', 'commands');
+      const commandsDir = join(ROOT, '.agents', 'commands');
       const commandNames = existsSync(commandsDir)
         ? new Set(readdirSync(commandsDir).filter(f => f.endsWith('.md') && f !== 'README.md').map(f => f.replace('.md', '')))
         : new Set();

--- a/tests/workflow/invariants.mjs
+++ b/tests/workflow/invariants.mjs
@@ -7,9 +7,9 @@ import { fileURLToPath } from 'url';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(__dirname, '..', '..');
 
-const COMMANDS_DIR = join(ROOT, '.opencode', 'commands');
-const SKILLS_DIR = join(ROOT, '.opencode', 'skills');
-const AGENTS_DIR = join(ROOT, '.opencode', 'agents');
+const COMMANDS_DIR = join(ROOT, '.agents', 'commands');
+const SKILLS_DIR = join(ROOT, '.agents', 'skills');
+const AGENTS_DIR = join(ROOT, '.agents', 'agents');
 const DOCS_DIR = join(ROOT, 'docs');
 const DESIGN_DIR = join(ROOT, 'design');
 const PRODUCTION_DIR = join(ROOT, 'production');
@@ -144,10 +144,10 @@ console.log('\n=== Cross-Cutting Invariants ===\n');
 
 { // I4: No stale template placeholders in key config files
   const configFiles = [
-    join(ROOT, '.opencode', 'docs', 'technical-preferences.md'),
+    join(ROOT, 'docs', 'framework', 'technical-preferences.md'),
   ];
   const knownPlaceholderFiles = new Set([
-    join(ROOT, '.opencode', 'docs', 'technical-preferences.md'),
+    join(ROOT, 'docs', 'framework', 'technical-preferences.md'),
   ]);
   const bad = [];
   for (const file of configFiles) {

--- a/tests/workflow/paths.mjs
+++ b/tests/workflow/paths.mjs
@@ -7,8 +7,8 @@ import { fileURLToPath } from 'url';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(__dirname, '..', '..');
 
-const SKILLS_DIR = join(ROOT, '.opencode', 'skills');
-const COMMANDS_DIR = join(ROOT, '.opencode', 'commands');
+const SKILLS_DIR = join(ROOT, '.agents', 'skills');
+const COMMANDS_DIR = join(ROOT, '.agents', 'commands');
 const DOCS_DIR = join(ROOT, 'docs');
 
 function getSkillContent(name) {

--- a/tests/workflow/references.mjs
+++ b/tests/workflow/references.mjs
@@ -7,9 +7,9 @@ import { fileURLToPath } from 'url';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(__dirname, '..', '..');
 
-const COMMANDS_DIR = join(ROOT, '.opencode', 'commands');
-const SKILLS_DIR = join(ROOT, '.opencode', 'skills');
-const AGENTS_DIR = join(ROOT, '.opencode', 'agents');
+const COMMANDS_DIR = join(ROOT, '.agents', 'commands');
+const SKILLS_DIR = join(ROOT, '.agents', 'skills');
+const AGENTS_DIR = join(ROOT, '.agents', 'agents');
 
 function parseFrontmatter(content) {
   const match = content.match(/^---\n([\s\S]*?)\n---/);


### PR DESCRIPTION
## Summary

Fixes #77 — framework validators crash with `ENOTDIR` on Windows when `.opencode/` symlinks materialize as plain text files (default `core.symlinks=false` without Developer Mode).

## Changes

Updated all validators to resolve `.agents/` canonical paths directly, bypassing the symlink layer:

| File | Change |
|------|--------|
| `tests/workflow/references.mjs` | commands/skills/agents dirs → `.agents/` |
| `tests/workflow/paths.mjs` | skills/commands dirs → `.agents/` |
| `tests/workflow/gates.mjs` | skills/commands dirs → `.agents/`, stale `.opencode/docs/` → `docs/framework/` |
| `tests/workflow/invariants.mjs` | commands/skills/agents dirs → `.agents/`, stale doc path → `docs/framework/` |
| `tests/modules/validate-modules.mjs` | PATH_MAP → `.agents/` (modules/plugins kept — real dirs) |
| `tests/agents/validate-gdscript.mjs` | agents dir → `.agents/` |

**Not affected** (intentionally unchanged): `.opencode/modules/` and `.opencode/plugins/` — these are real directories, not symlinks.

## Verification

- Agent validator: **206/206 pass**
- Workflow suites: **4/4 pass** (references, paths, gates, invariants)
- Module validator: **21/21 pass**