### PR TITLE
fix: point assign-models.js at canonical .agents/agents (#96)

### DIFF
--- a/utils/assign-models.js
+++ b/utils/assign-models.js
@@ -2,7 +2,7 @@
 const fs = require("fs");
 const path = require("path");
 
-const AGENTS_DIR = path.resolve(__dirname, "..", ".opencode", "agents");
+const AGENTS_DIR = path.resolve(__dirname, "..", ".agents", "agents");
 const MODEL_RE = /^(model:\s*).+/m;
 
 function usage() {


### PR DESCRIPTION
Closes #96.

`AGENTS_DIR` in `utils/assign-models.js` resolved to `.opencode/agents`, valid only when that symlink is correctly materialized (see #93). Anywhere it isn't, the script silently scans 0 agent files instead of erroring. Points it directly at `.agents/agents`, the canonical source of truth, regardless of `.opencode/` symlink state.

Verified: `node utils/assign-models.js --help` runs fine; `readdirSync` on the new path finds all 51 agent `.md` files.