### PR TITLE
chore: ignore stray coding-agent session transcripts (#97)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,5 +28,8 @@ desktop.ini
 *~
 tests/agents/validation-report.md
 
+# Coding-agent session transcripts accidentally dropped at repo root
+omp-session-*.html
+
 # Submodule dependencies
 tools/aseprite-mcp/.venv/


### PR DESCRIPTION
Closes #97.

An untracked `omp-session-*.html` transcript (467KB) was left at the repo root by a prior coding-agent session. It was never git-tracked, so it's already gone locally; this PR just adds a `.gitignore` pattern so future transcripts of this shape don't clutter `git status` or get accidentally committed.