### PR TITLE
fix: repair broken plugin test invocation in docs and package.json (#95)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -245,8 +245,8 @@ Before merging to `development`, the CI must pass:
   - All agent files have required frontmatter and sections
   - All skill files have valid cross-references to existing agents
   - All command files reference valid skill directories
-- **Plugin tests** (`node .opencode/plugins/tests/test-*.mjs`):
-  - 11 test suites, 129+ tests covering all hooks
+- **Plugin tests** (`npm run test:plugins`):
+  - 18 test suites, 158 tests covering all hooks
 
 ## Notes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ pi
 2. Discuss the approach with maintainers
 3. Fork the repo and create a branch
 4. Make your changes
-5. Run the plugin tests: `node .opencode/plugins/tests/test-<name>.mjs`
+5. Run the plugin tests: `npm run test:plugins` (needs the `tsx` ESM loader — a plain `node .opencode/plugins/tests/test-<name>.mjs` will fail, since the tests import `.ts` sources)
 6. Submit a pull request
 
 ## Commit Conventions

--- a/README.md
+++ b/README.md
@@ -346,7 +346,7 @@ All 12 bash hooks from CCGS ported to `ccgs-hooks.ts`:
 | 11 | `post-compact.sh` | `experimental.compaction.autocontinue` | **5** |
 | 12 | `notify.sh` | Utility (`showNotification`) | — |
 
-> 🧪 Run plugin test suite: `node .opencode/plugins/tests/test-<name>.mjs`
+> 🧪 Run plugin test suite: `npm run test:plugins` (needs the `tsx` ESM loader — see CONTRIBUTING.md)
 > 🧪 Run workflow integrity suite: `node tests/workflow/run-all.mjs`
 
 ### Contributing to the Framework

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "test": "node --import tsx --test .opencode/plugins/tests/test-*.mjs",
-    "test:plugins": "node --import tsx --test .opencode/plugins/tests/",
+    "test:plugins": "node --import tsx --test .opencode/plugins/tests/test-*.mjs",
     "test:framework": "node tests/agents/validate.mjs",
     "test:parity": "node --import tsx --test tests/e2e/test-parity.test.ts"
   },


### PR DESCRIPTION
Closes #95.

CONTRIBUTING.md, README.md, and AGENTS.md all instructed contributors to run `node .opencode/plugins/tests/test-<name>.mjs` directly — fails immediately with a SyntaxError, since the `.mjs` test files import `.ts` sources and need the `tsx` ESM loader.

**Found a second, deeper bug while fixing this**: the existing `npm run test:plugins` script (the documented correct alternative) was itself broken — it passed a bare directory to `node --test`, which throws `ERR_MODULE_NOT_FOUND` trying to resolve a nonexistent `.opencode/plugins/tests/index.ts` under the tsx loader. Fixed the script in `package.json` to use the same working glob (`test-*.mjs`) as the `test` script.

Docs now consistently point to `npm run test:plugins`, and a stale nearby test count (129+ -> 158) was corrected alongside.

## Verification
`npm run test:plugins` previously threw `ERR_MODULE_NOT_FOUND` on invocation; now runs to completion: **158/158 PASS**.