### PR TITLE
chore: prepare v0.13.0

### DIFF
--- a/.agents/agents/bevy-specialist.md
+++ b/.agents/agents/bevy-specialist.md
@@ -1,7 +1,5 @@
 ---
 description: "The Bevy Specialist is the authority on all Bevy-specific patterns, APIs, and build integration. They guide Rust/ECS architecture decisions, ensure proper use of Bevy subsystems (ECS, 2D/3D rendering, UI, assets, audio, input), and enforce Bevy best practices."
-mode: subagent
-model: opencode-go/qwen3.6-plus
 maxTurns: 20
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # OpenCode Game Studios
 
-Indie game development managed through 51 coordinated OpenCode agents.
+Indie game development managed through 52 coordinated OpenCode agents.
 Each agent owns a specific domain, enforcing separation of concerns and quality.
 
 ## Technology Stack
@@ -21,11 +21,11 @@ Each agent owns a specific domain, enforcing separation of concerns and quality.
 ├── opencode.json                # OpenCode config (permissions, plugins)
 ├── .pi/                         # Pi settings and extensions
 ├── .agents/                     # Canonical content (harness-agnostic)
-│   ├── agents/                  # 51 agent definitions
+│   ├── agents/                  # 52 agent definitions
 │   ├── skills/                  # 77 skill workflows
 │   ├── commands/                # 54 slash commands
 │   ├── rules/                   # 11 path-scoped coding standards
-│   └── modules/                 # 21 installable modules
+│   └── modules/                 # 22 installable modules
 ├── .opencode/                   # OpenCode-specific
 │   ├── plugins/                 # TypeScript plugins (ccgs-hooks, drift-detector, changelog-generator)
 │   ├── agents/ → ../.agents/agents/   (symlink)
@@ -252,7 +252,7 @@ Before merging to `development`, the CI must pass:
 ## Notes
 
 This is a port of [Claude Code Game Studios](https://github.com/Donchitos/Claude-Code-Game-Studios)
-to OpenCode. The 77 skills are in `.agents/skills/`, the 51 agents are in
+to OpenCode. The 77 skills are in `.agents/skills/`, the 52 agents are in
 `.agents/agents/`, and the 12 original bash hooks are implemented as a
 TypeScript plugin in `.opencode/plugins/ccgs-hooks.ts`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [v0.13.0] — 2026-08-10
+
+### Added
+
+- **Bevy engine support** — brings Bevy to parity with the other five engine specialists:
+  - `engine-bevy` module (`.agents/modules/` and `.opencode/modules/` trees) with a single
+    `bevy-specialist` agent covering ECS, 2D/3D rendering, bevy_ui, assets, audio, input,
+    Cargo build, and WASM/mobile targets
+  - 12 version-pinned reference docs at `docs/engine-reference/bevy/` (pinned **Bevy
+    0.19.0**, HIGH knowledge-gap risk) — VERSION, breaking-changes, deprecated-apis,
+    current-best-practices, and 8 module guides, every API claim source-cited against
+    official Bevy 0.19 migration guides and docs.rs
+  - `/setup-engine` guided selection, tradeoffs, genre guidance, Cargo scaffold, and
+    specialist routing for Bevy
+  - Cross-cutting updates: AGENTS.md, README.md, `init-template` skill, `engine-code` rule
+    (Rust/Bevy zero-alloc example), agent roster (#104)
+
+### Fixed
+
+- **Bevy agent frontmatter leak**: the canonical `.agents/agents/bevy-specialist.md` carried
+  OpenCode-only `mode`/`model` frontmatter fields that belong solely in the
+  `.opencode/modules/` copy, breaking parity with every other canonical engine specialist
+  and the harness-agnostic contract
+- **Stale agent/module counts**: adding the 22nd module and 52nd agent left README.md and
+  AGENTS.md still reporting "21 modules" / "51 agents" in six places; corrected to 22/52
+
+---
+
 ## [v0.12.1] — 2026-08-02
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ for the full game lifecycle:
 - **Workflow selection** — Choose Hybrid (lightweight discovery then production)
   or Full OCGS (process-heavy from day one), depending on team size and project
   maturity
-- **51 coordinated agents** — From creative director to engine specialists, each
+- **52 coordinated agents** — From creative director to engine specialists, each
   with defined responsibilities, delegation maps, and strict domain boundaries
 - **77 slash commands** — Route through the right skill every time, from
   `/concept-brainstorm` to `/launch-checklist`
@@ -71,7 +71,7 @@ and runs on [OpenCode](https://opencode.ai) and [Pi](https://github.com/earendil
 
 | Component | CCGS (Claude Code) | OpenCode | Pi | Status |
 |-----------|-------------------|----------|-----|--------|
-| 🤖 **Agents** | 49 agents (`.claude/agents/`) | 51 agents (`.agents/agents/`) | 51 agents (`.agents/agents/`) | ✅ |
+| 🤖 **Agents** | 49 agents (`.claude/agents/`) | 52 agents (`.agents/agents/`) | 52 agents (`.agents/agents/`) | ✅ |
 | ⌨️ **Skills** | 72 skills (`.claude/skills/`) | 77 skills (`.agents/skills/`) | 77 skills (`.agents/skills/`) | ✅ +5 |
 | ⌨️ **Commands** | — | 77 commands (`.agents/commands/`) | → prompt templates | ✅ New |
 | 🔗 **Plugins** | 12 bash hooks (`.claude/hooks/`) | 3 TS plugins (`.opencode/plugins/`) | 7 Pi extensions (`.pi/extensions/`) | ✅ **158 tests** |
@@ -105,7 +105,7 @@ See [**OCGS-Pong**](https://github.com/striderZA/OCGS-Pong) — a complete Pong 
 
 ## 🧩 Modular Framework
 
-The framework is partitioned into **21 pluggable theme modules**. Only install what you need for your project:
+The framework is partitioned into **22 pluggable theme modules**. Only install what you need for your project:
 
 | Module | Description |
 |--------|-------------|
@@ -272,12 +272,12 @@ node utils/assign-models.js --config my-models.json
 ├── opencode.json              ⚙️ OpenCode config (permissions, plugins)
 ├── .pi/                       ⚙️ Pi config (extensions, settings)
 ├── .agents/                   📦 Canonical content (harness-agnostic)
-│   ├── agents/                🤖 51 agent definitions
+│   ├── agents/                🤖 52 agent definitions
 │   ├── skills/                🛠️ 77 skill workflows
 │   ├── commands/              ⌨️ 54 slash commands
 │   ├── rules/                 📏 11 coding standards
-│   └── modules/               🧩 21 pluggable theme modules
-│       ├── ...                21 modules total
+│   └── modules/               🧩 22 pluggable theme modules
+│       ├── ...                22 modules total
 ├── .opencode/                 ⚙️ OpenCode-specific (plugins, config)
 │   ├── commands/ → .agents/commands/ (symlink)
 │   ├── agents/ → .agents/agents/     (symlink)
@@ -291,7 +291,7 @@ node utils/assign-models.js --config my-models.json
 │   └── modules/
 │       ├── install.mjs        CLI: add/remove/list modules
 │       ├── installed.json     Module manifest
-│       └── ...                21 module sources
+│       └── ...                22 module sources
 ├── design/                    🎨 Game design documents
 ├── .pi/                        ⚙️ Pi-specific extensions & settings
 │   └── extensions/            🧩 Pi extensions (ocgs-core, delegation, question, etc.)


### PR DESCRIPTION
## Summary

Follow-up to #104 (Bevy engine support) plus release prep for v0.13.0.

### Fixed
- **Bevy agent frontmatter leak**: removed OpenCode-only `mode`/`model` fields from the canonical `.agents/agents/bevy-specialist.md` (the only one of 52 canonical specialists carrying them) so it matches every sibling engine specialist and the harness-agnostic contract.
- **Stale doc counts**: bumped `21 modules -> 22` and `51 agents -> 52` across README.md and AGENTS.md (6 locations) left behind by the Bevy module/agent addition.

### Added
- CHANGELOG.md entry for v0.13.0.

### Verification
- `node tests/agents/validate.mjs` -> PASS, 207/207, 100% coverage
- `npm run test:plugins` -> 158/158 pass
