### PR TITLE
fix: align framework docs with canonical counts and stale references

### DIFF
--- a/.agents/modules/core/docs/workflow-catalog.yaml
+++ b/.agents/modules/core/docs/workflow-catalog.yaml
@@ -22,7 +22,7 @@ phases:
     steps:
       - id: brainstorm
         name: "Brainstorm"
-        command: /brainstorm
+        command: /concept-brainstorm
         required: false
         description: "Explore the game concept using MDA, verb-first, and player psychology frameworks"
 
@@ -37,7 +37,7 @@ phases:
 
       - id: game-concept
         name: "Game Concept Document"
-        command: /brainstorm
+        command: /concept-brainstorm
         required: true
         artifact:
           glob: "design/gdd/game-concept.md"
@@ -55,7 +55,7 @@ phases:
         required: true
         artifact:
           glob: "design/art/art-bible.md"
-        description: "Author the visual identity specification (9 sections). Uses the Visual Identity Anchor produced by /brainstorm. Run after game concept is formed, before systems design."
+        description: "Author the visual identity specification (9 sections). Uses the Visual Identity Anchor produced by /concept-brainstorm. Run after game concept is formed, before systems design."
 
       - id: map-systems
         name: "Systems Map"

--- a/.agents/modules/engine-unity/modulefile.yaml
+++ b/.agents/modules/engine-unity/modulefile.yaml
@@ -1,5 +1,5 @@
 name: engine-unity
-version: "0.7.0"
+version: "0.6.0"
 description: "Unity engine specialists — DOTS/ECS, shaders, Addressables, UI. Includes unity-mcp integration for interactive AI-assisted dev."
 depends: [core]
 provides:

--- a/.agents/modules/installed.json
+++ b/.agents/modules/installed.json
@@ -351,7 +351,9 @@
     "version": "0.6.0",
     "status": "installed",
     "timestamp": "2026-08-09T19:15:25.684Z",
-    "files": [],
+    "files": [
+      "agents/bevy-specialist.md"
+    ],
     "mcp": []
   }
 }

--- a/.github/workflows/agent-validation.yml
+++ b/.github/workflows/agent-validation.yml
@@ -51,3 +51,18 @@ jobs:
           node-version: 20
       - name: Validate module structure
         run: node tests/modules/validate-modules.mjs
+
+  validate-plugins:
+    runs-on: ubuntu-latest
+    name: Plugin Tests
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: recursive
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 20
+      - name: Install dependencies
+        run: npm ci
+      - name: Run plugin test suite
+        run: npm run test:plugins

--- a/.opencode/modules/core/docs/workflow-catalog.yaml
+++ b/.opencode/modules/core/docs/workflow-catalog.yaml
@@ -22,7 +22,7 @@ phases:
     steps:
       - id: brainstorm
         name: "Brainstorm"
-        command: /brainstorm
+        command: /concept-brainstorm
         required: false
         description: "Explore the game concept using MDA, verb-first, and player psychology frameworks"
 
@@ -37,7 +37,7 @@ phases:
 
       - id: game-concept
         name: "Game Concept Document"
-        command: /brainstorm
+        command: /concept-brainstorm
         required: true
         artifact:
           glob: "design/gdd/game-concept.md"
@@ -55,7 +55,7 @@ phases:
         required: true
         artifact:
           glob: "design/art/art-bible.md"
-        description: "Author the visual identity specification (9 sections). Uses the Visual Identity Anchor produced by /brainstorm. Run after game concept is formed, before systems design."
+        description: "Author the visual identity specification (9 sections). Uses the Visual Identity Anchor produced by /concept-brainstorm. Run after game concept is formed, before systems design."
 
       - id: map-systems
         name: "Systems Map"

--- a/.opencode/modules/engine-unity/modulefile.yaml
+++ b/.opencode/modules/engine-unity/modulefile.yaml
@@ -1,5 +1,5 @@
 name: engine-unity
-version: "0.7.0"
+version: "0.6.0"
 description: "Unity engine specialists — DOTS/ECS, shaders, Addressables, UI. Includes unity-mcp integration for interactive AI-assisted dev."
 depends: [core]
 provides:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@ Each agent owns a specific domain, enforcing separation of concerns and quality.
 ├── .agents/                     # Canonical content (harness-agnostic)
 │   ├── agents/                  # 52 agent definitions
 │   ├── skills/                  # 77 skill workflows
-│   ├── commands/                # 54 slash commands
+│   ├── commands/                # 77 slash commands
 │   ├── rules/                   # 11 path-scoped coding standards
 │   └── modules/                 # 22 installable modules
 ├── .opencode/                   # OpenCode-specific
@@ -196,16 +196,16 @@ corresponding skills in `.agents/skills/`.
 
 | Category | Commands |
 |----------|----------|
-| **Onboarding** | `/start`, `/help`, `/project-stage-detect`, `/setup-engine`, `/init-template` |
-| **Design** | `/concept-brainstorm`, `/map-systems`, `/design-system`, `/quick-design`, `/design-review`, `/review-all-gdds` |
+| **Onboarding** | `/start`, `/help`, `/project-stage-detect`, `/setup-engine`, `/init-template`, `/adopt` |
+| **Design** | `/concept-brainstorm`, `/map-systems`, `/design-system`, `/quick-design`, `/design-review`, `/review-all-gdds`, `/ux-design`, `/ux-review` |
 | **Architecture** | `/create-architecture`, `/architecture-decision`, `/architecture-review`, `/create-control-manifest` |
 | **Stories** | `/create-epics`, `/create-stories`, `/story-readiness`, `/dev-story`, `/story-done`, `/code-review` |
 | **QA** | `/qa-plan`, `/smoke-check`, `/soak-test`, `/regression-suite`, `/test-setup`, `/test-helpers`, `/test-evidence-review`, `/test-flakiness` |
-| **Prototyping** | `/prototype`, `/reverse-document` |
-| **Team** | `/team-combat`, `/team-narrative`, `/team-ui`, `/team-level`, `/team-audio`, `/team-polish`, `/team-qa`, `/team-release` |
+| **Prototyping** | `/prototype`, `/hybrid-prototype`, `/explore`, `/reverse-document` |
+| **Team** | `/team-combat`, `/team-narrative`, `/team-ui`, `/team-level`, `/team-audio`, `/team-polish`, `/team-qa`, `/team-release`, `/team-live-ops` |
 | **Release** | `/sprint-plan`, `/sprint-status`, `/milestone-review`, `/release-checklist`, `/launch-checklist`, `/retrospective` |
 | **Ops** | `/hotfix`, `/day-one-patch`, `/bug-report`, `/bug-triage`, `/security-audit` |
-| **Other** | `/balance-check`, `/consistency-check`, `/content-audit`, `/asset-audit`, `/perf-profile`, `/scope-check`, `/gate-check`, `/changelog`, `/patch-notes`, `/localize`, `/onboard`, `/tech-debt`, `/propagate-design-change`, `/estimate`, `/art-bible`, `/asset-spec`, `/playtest-report`, `/automated-smoke-test` |
+| **Other** | `/balance-check`, `/consistency-check`, `/content-audit`, `/asset-audit`, `/perf-profile`, `/scope-check`, `/gate-check`, `/changelog`, `/patch-notes`, `/localize`, `/onboard`, `/tech-debt`, `/propagate-design-change`, `/estimate`, `/art-bible`, `/asset-spec`, `/art-generate`, `/playtest-report`, `/automated-smoke-test`, `/skill-improve`, `/skill-test` |
 
 ## Studio Hierarchy
 

--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ node utils/assign-models.js --config my-models.json
 ├── .agents/                   📦 Canonical content (harness-agnostic)
 │   ├── agents/                🤖 52 agent definitions
 │   ├── skills/                🛠️ 77 skill workflows
-│   ├── commands/              ⌨️ 54 slash commands
+│   ├── commands/              ⌨️ 77 slash commands
 │   ├── rules/                 📏 11 coding standards
 │   └── modules/               🧩 22 pluggable theme modules
 │       ├── ...                22 modules total
@@ -351,6 +351,7 @@ All 12 bash hooks from CCGS ported to `ccgs-hooks.ts`:
 
 > 🧪 Run plugin test suite: `npm run test:plugins` (needs the `tsx` ESM loader — see CONTRIBUTING.md)
 > 🧪 Run workflow integrity suite: `node tests/workflow/run-all.mjs`
+> 🧪 Run e2e parity suite: `npm run test:parity` (requires both the `opencode` and `pi` CLIs installed)
 
 ### Contributing to the Framework
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -30,4 +30,6 @@ ADR Dependencies, Engine Compatibility, GDD Requirements Addressed
 Version-pinned engine API snapshots. **Always check here before using any
 engine API** — the LLM's training data predates the pinned engine version.
 
-Current engine: see `docs/engine-reference/godot/VERSION.md`
+Pinned engines: see `docs/engine-reference/<engine>/VERSION.md` for each
+supported engine (godot, unity, unreal, sfml3, raylib, bevy) before suggesting
+any engine API.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -24,9 +24,9 @@ The OCGS framework has 5 component types:
 
 | Component | Location | Purpose |
 |-----------|----------|---------|
-| **Agents** | `.agents/agents/` | Agent definitions (51 files) |
+| **Agents** | `.agents/agents/` | Agent definitions (52 files) |
 | **Skills** | `.agents/skills/` | Skill workflows (77 directories) |
-| **Commands** | `.agents/commands/` | Slash commands (54 files) |
+| **Commands** | `.agents/commands/` | Slash commands (77 files) |
 | **Rules** | `.agents/rules/` | Coding standards (11 files) |
 | **Plugins** | `.opencode/plugins/` | OpenCode TypeScript hooks |
 

--- a/docs/WORKFLOW-GUIDE.md
+++ b/docs/WORKFLOW-GUIDE.md
@@ -3,7 +3,7 @@
 > **How to go from zero to a shipped game using the Agent Architecture.**
 >
 > This guide walks you through every phase of game development using the
-> 51-agent system, 54 slash commands, and 3 TypeScript plugins. It assumes you
+> 52-agent system, 77 slash commands, and 3 TypeScript plugins. It assumes you
 > have OpenCode installed and are working from the project root.
 >
 > > **Pi users:** See [`docs/pi-workflow.md`](pi-workflow.md) for harness-specific differences and

--- a/docs/engine-reference/README.md
+++ b/docs/engine-reference/README.md
@@ -21,6 +21,7 @@ Each engine gets its own directory:
 ├── breaking-changes.md     # API changes between versions, organized by risk level
 ├── deprecated-apis.md      # "Don't use X → Use Y" lookup tables
 ├── current-best-practices.md  # New practices not in model training data
+├── PLUGINS.md              # Engine plugin/extension API notes (unity/, unreal/)
 └── modules/                # Per-subsystem quick references (~150 lines max each)
     ├── rendering.md
     ├── physics.md

--- a/docs/framework/agent-roster.md
+++ b/docs/framework/agent-roster.md
@@ -63,6 +63,8 @@ agent (usually `producer` or the domain lead) should delegate to specialists.
 | `unity-specialist` | Unity | Sonnet | MonoBehaviour vs DOTS, Addressables, URP/HDRP, Unity optimization |
 | `godot-specialist` | Godot 4 | Sonnet | GDScript patterns, node/scene architecture, signals, Godot optimization |
 | `bevy-specialist` | Bevy | Sonnet | ECS architecture, 2D/3D rendering, bevy_ui, Cargo build, Bevy optimization |
+| `sfml-specialist` | SFML 3 | Sonnet | Graphics, Audio, Network, Window, System modules, C++ patterns |
+| `raylib-specialist` | Raylib | Sonnet | core, rlgl, raudio, raymath, raygui, C patterns |
 
 ### Unreal Engine Sub-Specialists
 
@@ -87,5 +89,6 @@ agent (usually `producer` or the domain lead) should delegate to specialists.
 | Agent | Subsystem | Model | When to Use |
 | ---- | ---- | ---- | ---- |
 | `godot-gdscript-specialist` | GDScript | Sonnet | Static typing, design patterns, signals, coroutines, GDScript performance |
+| `godot-csharp-specialist` | C# | Sonnet | C# bindings, .NET integration, C# project structure, C# performance |
 | `godot-shader-specialist` | Shaders/Rendering | Sonnet | Godot shading language, visual shaders, particles, post-processing |
 | `godot-gdextension-specialist` | GDExtension | Sonnet | C++/Rust bindings, native performance, custom nodes, build systems |

--- a/docs/framework/directory-structure.md
+++ b/docs/framework/directory-structure.md
@@ -5,11 +5,11 @@
 ├── AGENTS.md                    # Master configuration
 ├── opencode.json                # OpenCode config (permissions, plugins)
 ├── .agents/                     # Canonical content (harness-agnostic)
-│   ├── agents/                  # 51 agent definitions
+│   ├── agents/                  # 52 agent definitions
 │   ├── skills/                  # 77 skill workflows
-│   ├── commands/                # 54 slash commands
+│   ├── commands/                # 77 slash commands
 │   ├── rules/                   # 11 path-scoped coding standards
-│   └── modules/                 # 21 theme modules (source of truth)
+│   └── modules/                 # 22 theme modules (source of truth)
 │       ├── installed.json       # Manifest of installed modules
 │       ├── core/                # Core module (always installed)
 │       ├── art/                 # Art module (aseprite MCP, art bible)
@@ -19,8 +19,9 @@
 │       ├── engine-unreal/       # Unreal Engine 5 specialists
 │       ├── engine-sfml3/        # SFML 3 specialist
 │       ├── engine-raylib/       # Raylib specialist
+│       ├── engine-bevy/         # Bevy specialist
 │       ├── qa/                  # QA module (testing, profiling, security)
-│       └── ...                  # 21 modules total
+│       └── ...                  # 22 modules total
 ├── .opencode/                   # OpenCode-specific (plugins, symlinks)
 │   ├── agents/ → ../.agents/agents/    (symlink)
 │   ├── skills/ → ../.agents/skills/    (symlink)
@@ -30,7 +31,7 @@
 │   │   ├── ccgs-hooks.ts       # Session lifecycle, validation
 │   │   ├── drift-detector.ts   # Template drift detection
 │   │   ├── changelog-generator.ts
-│   │   └── tests/              # 11 test suites (140+ tests)
+│   │   └── tests/              # 18 test suites (158 tests)
 │   └── modules/
 │       ├── install.mjs          # CLI: add/remove/list modules
 │       └── installed.json       # Module manifest
@@ -87,7 +88,7 @@
    contains agents, skills, commands, and rules for a domain. Install with
    `node .opencode/modules/install.mjs add <name>`.
 
-4. **21 modules available**: core, art, design, architecture, stories, programming,
+4. **22 modules available**: core, art, design, architecture, stories, programming,
    ui, audio, narrative, level-design, qa, release, prototyping, live-ops,
    localization, data, engine-godot, engine-unity, engine-unreal, engine-sfml3,
-   engine-raylib.
+   engine-raylib, engine-bevy.

--- a/docs/framework/hybrid-workflow.md
+++ b/docs/framework/hybrid-workflow.md
@@ -83,7 +83,7 @@ Build, polish, and ship the game with full quality gates.
 > **Note**: The `producer` role is merged into `technical-director`. Cross-domain coordination falls to `technical-director` (sprint planning, milestone reviews, scope management). Gate checks and release coordination are shared with `creative-director`. Design conflicts escalate to `creative-director`.
 
 ### Merged / Deferred Roles
-The following roles from the full 49-agent roster are either merged into the 10 above, or deferred until late production:
+The following roles from the full 52-agent roster are either merged into the 10 above, or deferred until late production:
 
 - `engine-programmer`, `tools-programmer` → `lead-programmer`
 - `ai-programmer`, `network-programmer` → `gameplay-programmer` (until needed)
@@ -140,7 +140,7 @@ A new skill/command that shortcuts the path to a playable prototype:
 
 ## When to Switch to Full OCGS
 
-Switch back to the **full 49-agent framework** if any of these become true:
+Switch back to the **full 52-agent framework** if any of these become true:
 - Team grows beyond 5 people
 - Project timeline exceeds 6 months
 - Multiple features need parallel development

--- a/docs/framework/quick-start.md
+++ b/docs/framework/quick-start.md
@@ -8,11 +8,12 @@
 
 This is a complete agent architecture for game development, supporting both
 [OpenCode](https://opencode.ai) and [Pi](https://github.com/earendil-works/pi-coding-agent). It
-organizes 48 specialized AI agents into a studio hierarchy that mirrors
+organizes 52 specialized AI agents into a studio hierarchy that mirrors
 real game development teams, with defined responsibilities, delegation
 rules, and coordination protocols. It includes engine-specialist agents
 for Godot, Unity, and Unreal — each with dedicated sub-specialists for
-major engine subsystems. All design agents and templates are grounded in
+major engine subsystems, plus single-specialist coverage for Bevy, SFML 3,
+and Raylib. All design agents and templates are grounded in
 established game design theory (MDA Framework, Self-Determination Theory,
 Flow State, Bartle Player Types). Use whichever engine set matches your project.
 

--- a/docs/framework/skills-reference.md
+++ b/docs/framework/skills-reference.md
@@ -1,6 +1,6 @@
 # Available Skills (Slash Commands)
 
-73 slash commands organized by phase. Each skill belongs to a **module** under
+77 slash commands organized by phase. Each skill belongs to a **module** under
 `.agents/modules/<name>/skills/`. Install only the modules you need:
 `node .opencode/modules/install.mjs add <name>`. Type `/` in OpenCode to access
 any available command.
@@ -33,6 +33,14 @@ any available command.
 |---------|---------|
 | `/ux-design` | Guided section-by-section UX spec authoring (screen/flow, HUD, or pattern library) |
 | `/ux-review` | Validate UX specs for GDD alignment, accessibility, and pattern compliance |
+
+## Art & Assets
+
+| Command | Purpose |
+|---------|---------|
+| `/art-bible` | Guided, section-by-section Art Bible authoring — the visual identity spec that gates all asset production |
+| `/asset-spec` | Generate per-asset visual specifications and AI generation prompts from GDDs and level docs |
+| `/art-generate` | Generate placeholder .aseprite files from asset specs using the Aseprite MCP |
 
 ## Architecture
 
@@ -70,6 +78,7 @@ any available command.
 | `/tech-debt` | Scan, track, prioritize, and report on technical debt |
 | `/gate-check` | Validate readiness to advance between development phases (PASS/CONCERNS/FAIL) |
 | `/consistency-check` | Scan all GDDs against the entity registry to detect cross-document inconsistencies (stats, names, rules that contradict each other) |
+| `/security-audit` | Audit the game for security vulnerabilities: save tampering, cheat vectors, network exploits, data exposure |
 
 ## QA & Testing
 
@@ -85,6 +94,7 @@ any available command.
 | `/test-evidence-review` | Quality review of test files and manual evidence documents |
 | `/test-flakiness` | Detect non-deterministic (flaky) tests from CI run logs |
 | `/skill-test` | Validate skill files for structural compliance and behavioral correctness |
+| `/skill-improve` | Improve a skill using a test-fix-retest loop |
 
 ## Production
 
@@ -106,6 +116,7 @@ any available command.
 | `/changelog` | Auto-generate changelog from git commits and sprint data |
 | `/patch-notes` | Generate player-facing patch notes from git history and internal data |
 | `/hotfix` | Emergency fix workflow with audit trail, bypassing normal sprint process |
+| `/day-one-patch` | Prepare a scoped, QA-gated day-one patch for post-launch issues |
 
 ## Creative & Content
 
@@ -113,6 +124,7 @@ any available command.
 |---------|---------|
 | `/prototype` | Rapid throwaway prototype to validate a mechanic (relaxed standards, isolated worktree) |
 | `/hybrid-prototype` | Fast-lane prototype for discovery phase — 2-3 day build, no formal gates, lightweight DECISION.md |
+| `/explore` | Pre-workflow rapid prototyping — compare multiple game ideas with zero workflow commitment |
 | `/onboard` | Generate contextual onboarding document for a new contributor or agent |
 | `/localize` | Localization workflow: string extraction, validation, translation readiness |
 

--- a/docs/framework/workflow-catalog.yaml
+++ b/docs/framework/workflow-catalog.yaml
@@ -22,7 +22,7 @@ phases:
     steps:
       - id: brainstorm
         name: "Brainstorm"
-        command: /brainstorm
+        command: /concept-brainstorm
         required: false
         description: "Explore the game concept using MDA, verb-first, and player psychology frameworks"
 
@@ -37,7 +37,7 @@ phases:
 
       - id: game-concept
         name: "Game Concept Document"
-        command: /brainstorm
+        command: /concept-brainstorm
         required: true
         artifact:
           glob: "design/gdd/game-concept.md"
@@ -55,7 +55,7 @@ phases:
         required: true
         artifact:
           glob: "design/art/art-bible.md"
-        description: "Author the visual identity specification (9 sections). Uses the Visual Identity Anchor produced by /brainstorm. Run after game concept is formed, before systems design."
+        description: "Author the visual identity specification (9 sections). Uses the Visual Identity Anchor produced by /concept-brainstorm. Run after game concept is formed, before systems design."
 
       - id: map-systems
         name: "Systems Map"

--- a/docs/hybrid-workflow.md
+++ b/docs/hybrid-workflow.md
@@ -71,7 +71,7 @@ Build, polish, and ship the game with full quality gates.
 - Every system has an ADR in `docs/architecture/`.
 - Tests first for gameplay systems (TDD).
 
-### Slimmed Agent Hierarchy (49 → 10)
+### Slimmed Agent Hierarchy (52 → 10)
 
 | Tier | Role | Responsibilities |
 |------|------|------------------|
@@ -89,7 +89,7 @@ Build, polish, and ship the game with full quality gates.
 > **Note**: The `producer` role is merged into `technical-director`. Cross-domain coordination falls to `technical-director` (sprint planning, milestone reviews, scope management). Gate checks and release coordination are shared with `creative-director`. Design conflicts escalate to `creative-director`.
 
 ### Merged / Deferred Roles
-The following roles from the full 51-agent roster are either merged into the 10 above, or deferred until late production:
+The following roles from the full 52-agent roster are either merged into the 10 above, or deferred until late production:
 
 - `engine-programmer`, `tools-programmer` → `lead-programmer`
 - `ai-programmer`, `network-programmer` → `gameplay-programmer` (until needed)
@@ -146,7 +146,7 @@ A new skill/command that shortcuts the path to a playable prototype:
 
 ## When to Switch to Full OCGS
 
-Switch to the **full 51-agent framework** if any of these become true:
+Switch to the **full 52-agent framework** if any of these become true:
 - Team grows beyond 5 people
 - Project timeline exceeds 6 months
 - Multiple features need parallel development

--- a/docs/pi-compatibility.md
+++ b/docs/pi-compatibility.md
@@ -14,11 +14,11 @@ All OCGS skills, commands, and agents are available automatically through the `.
 
 ```
 .agents/                     ← Canonical content (harness-agnostic)
-  agents/                    ← 51 agent definitions
+  agents/                    ← 52 agent definitions
   skills/                    ← 77 skill workflows
   commands/                  ← 77 slash commands
   rules/                     ← 11 path-scoped rules
-  modules/                   ← 21 installable modules
+  modules/                   ← 22 installable modules
 .opencode/                   ← OpenCode-specific plugins & config
 .pi/                         ← Pi-specific extensions & settings
 ```

--- a/docs/pi-extensions.md
+++ b/docs/pi-extensions.md
@@ -34,7 +34,7 @@ Two cross-harness delegation primitives: `Task` tool (vertical execution) and `/
 pi.registerTool({
   name: "Task",
   parameters: {
-    agent: StringEnum([...51 agent names]),  // Optional, auto-detected
+    agent: StringEnum([...52 agent names]),  // Optional, auto-detected
     prompt: string,                           // What to delegate
     context?: string,                         // Optional additional context
     isolation?: "same-context" | "forked",    // Default: same-context

--- a/docs/pi-workflow.md
+++ b/docs/pi-workflow.md
@@ -40,7 +40,7 @@ Agent prompts reference the `Task` tool identically in both harnesses:
 
 > "Use the `Task` tool to delegate to `game-designer`: 'Review the combat system GDD'"
 
-In Pi, `ocgs-delegation` registers this tool with all 51 agent names discovered from `.agents/agents/`. The subagent runs in-memory and returns the result.
+In Pi, `ocgs-delegation` registers this tool with all 52 agent names discovered from `.agents/agents/`. The subagent runs in-memory and returns the result.
 
 ### Peer Review (/consult)
 


### PR DESCRIPTION
## Summary

Framework-wide documentation consistency fix after a six-scout audit of AGENTS.md, docs/, tests/, and module manifests. All counts now match the canonical source of truth: **52 agents / 77 commands / 22 modules / 11 rules**.

## What changed

**Count corrections (52 / 77 / 22)** across AGENTS.md, README, docs/framework/*, docs/pi-*.md, docs/WORKFLOW-GUIDE.md, docs/CONTRIBUTING.md, docs/hybrid-workflow.md.

**Completeness fixes**
- AGENTS.md command table: added 9 undocumented commands (adopt, ux-design, ux-review, explore, hybrid-prototype, team-live-ops, art-generate, skill-improve, skill-test)
- skills-reference.md: 73 → 77 commands; added 7 missing skills (art-bible, asset-spec, art-generate, security-audit, skill-improve, day-one-patch, explore)
- agent-roster.md: added missing godot-csharp-specialist, raylib-specialist, sfml-specialist (now 52/52)
- directory-structure.md: added engine-bevy module; plugin test count 11/140+ → 18/158

**Bug fixes**
- .agents/modules/installed.json: engine-bevy manifest had empty `files` array — populated with agents/bevy-specialist.md (OpenCode manifest was correct; Pi manifest stale)
- workflow-catalog.yaml: /brainstorm → /concept-brainstorm in docs/ + both core-module copies
- CI: added validate-plugins job — the advertised 18-suite/158-test plugin suite was never run in agent-validation.yml
- engine-unity modulefile: aligned 0.7.0 → 0.6.0 to match manifest + sibling modules

**Documentation**
- docs/AGENTS.md: de-hardcoded godot as the current engine
- engine-reference/README.md: documented PLUGINS.md structure
- README.md: documented npm run test:parity

## Verification

- `node tests/agents/validate.mjs` → 207/207 PASS
- `node tests/workflow/run-all.mjs` → 4/4 suites PASS
- `node tests/modules/validate-modules.mjs` → 22/22 PASS
- `npm run test:plugins` → 18 suites, 158 tests, 0 fail
- Repo-wide grep: no stale counts, no /brainstorm references remaining